### PR TITLE
Mock location bearing

### DIFF
--- a/lost-sample/src/main/java/com/example/lost/LostActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/LostActivity.java
@@ -225,12 +225,14 @@ public class LostActivity extends AppCompatActivity {
         final TextView coordinates = (TextView) view.findViewById(R.id.coordinates);
         final TextView accuracy = (TextView) view.findViewById(R.id.accuracy);
         final TextView speed = (TextView) view.findViewById(R.id.speed);
+        final TextView bearing = (TextView) view.findViewById(R.id.bearing);
         final TextView time = (TextView) view.findViewById(R.id.time);
 
         provider.setText("");
         coordinates.setText("");
         accuracy.setText("");
         speed.setText("");
+        bearing.setText("");
         time.setText("");
     }
 

--- a/lost-sample/src/main/java/com/example/lost/LostActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/LostActivity.java
@@ -208,6 +208,7 @@ public class LostActivity extends AppCompatActivity {
         final TextView coordinates = (TextView) view.findViewById(R.id.coordinates);
         final TextView accuracy = (TextView) view.findViewById(R.id.accuracy);
         final TextView speed = (TextView) view.findViewById(R.id.speed);
+        final TextView bearing = (TextView) view.findViewById(R.id.bearing);
         final TextView time = (TextView) view.findViewById(R.id.time);
 
         provider.setText(location.getProvider() + " provider");
@@ -215,6 +216,7 @@ public class LostActivity extends AppCompatActivity {
                 location.getLongitude()));
         accuracy.setText("within " + Math.round(location.getAccuracy()) + " meters");
         speed.setText(location.getSpeed() + " m/s");
+        bearing.setText(location.getBearing() + " degrees");
         time.setText(new Date(location.getTime()).toString());
     }
 

--- a/lost-sample/src/main/res/layout/list_item.xml
+++ b/lost-sample/src/main/res/layout/list_item.xml
@@ -28,6 +28,11 @@
         android:layout_height="wrap_content" />
 
     <TextView
+        android:id="@+id/bearing"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <TextView
         android:id="@+id/time"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />

--- a/lost/build.gradle
+++ b/lost/build.gradle
@@ -71,7 +71,7 @@ dependencies {
   compile 'com.google.guava:guava:18.0'
 
   testCompile 'junit:junit:4.12'
-  testCompile 'org.robolectric:robolectric:3.0-rc3'
+  testCompile 'org.robolectric:robolectric:3.0'
   testCompile 'com.squareup:fest-android:1.0.7'
 }
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/MockEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/MockEngine.java
@@ -76,6 +76,7 @@ public class MockEngine extends LocationEngine {
 
     private class TraceThread extends Thread {
         private boolean canceled;
+        private Location previous;
 
         public void cancel() {
             canceled = true;
@@ -131,6 +132,11 @@ public class MockEngine extends LocationEngine {
             location.setTime(System.currentTimeMillis());
             location.setSpeed(Float.parseFloat(speedList.item(i).getFirstChild().getNodeValue()));
 
+            if (previous != null) {
+                location.setBearing(previous.bearingTo(location));
+            }
+
+            previous = location;
             return location;
         }
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -8,7 +8,6 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -252,7 +251,7 @@ public class FusedLocationProviderApiImplTest {
         assertThat(listener.getMostRecentLocation()).isEqualTo(mockLocation);
     }
 
-    @Test @Ignore("Find a better way to test this without Thread.sleep()")
+    @Test
     public void setMockTrace_shouldInvokeListenerForEachLocation() throws Exception {
         api.setMockMode(true);
         api.setMockTrace(getTestGpxTrace());
@@ -260,7 +259,7 @@ public class FusedLocationProviderApiImplTest {
         LocationRequest request = LocationRequest.create();
         request.setFastestInterval(0);
         api.requestLocationUpdates(request, listener);
-        Thread.sleep(1000);
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(listener.getAllLocations()).hasSize(3);
         assertThat(listener.getAllLocations().get(0).getLatitude()).isEqualTo(0.0);
@@ -271,7 +270,7 @@ public class FusedLocationProviderApiImplTest {
         assertThat(listener.getAllLocations().get(2).getLongitude()).isEqualTo(2.1);
     }
 
-    @Test @Ignore("Find a better way to test this without Thread.sleep()")
+    @Test
     public void setMockTrace_shouldBroadcastSpeedWithLocation() throws Exception {
         api.setMockMode(true);
         api.setMockTrace(getTestGpxTrace());
@@ -279,28 +278,28 @@ public class FusedLocationProviderApiImplTest {
         LocationRequest request = LocationRequest.create();
         request.setFastestInterval(0);
         api.requestLocationUpdates(request, listener);
-        Thread.sleep(1000);
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(listener.getAllLocations().get(0).getSpeed()).isEqualTo(10f);
         assertThat(listener.getAllLocations().get(1).getSpeed()).isEqualTo(20f);
         assertThat(listener.getAllLocations().get(2).getSpeed()).isEqualTo(30f);
     }
 
-    @Test @Ignore("Find a better way to test this without Thread.sleep()")
+    @Test
     public void setMockTrace_shouldRespectFastestInterval() throws Exception {
         api.setMockMode(true);
         api.setMockTrace(getTestGpxTrace());
         TestLocationListener listener = new TestLocationListener();
         LocationRequest request = LocationRequest.create();
-        request.setInterval(1000);
+        request.setInterval(100);
         api.requestLocationUpdates(request, listener);
-        Thread.sleep(1000);
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(listener.getAllLocations()).hasSize(1);
-        Thread.sleep(1000);
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(listener.getAllLocations()).hasSize(2);
-        Thread.sleep(1000);
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(listener.getAllLocations()).hasSize(3);
     }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/MockEngineTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/MockEngineTest.java
@@ -76,16 +76,40 @@ public class MockEngineTest {
     }
 
     @Test
+    public void setTrace_shouldCalculateBearing() throws Exception {
+        mockEngine.setTrace(getTestGpxTrace());
+        mockEngine.setRequest(LocationRequest.create().setFastestInterval(0));
+        Thread.sleep(100);
+        ShadowLooper.runUiThreadTasks();
+        assertThat(callback.locations.get(0).getBearing()).isEqualTo(0.0f);
+        assertThat(callback.locations.get(1).getBearing())
+                .isEqualTo(callback.locations.get(0).bearingTo(callback.locations.get(1)));
+        assertThat(callback.locations.get(2).getBearing())
+                .isEqualTo(callback.locations.get(1).bearingTo(callback.locations.get(2)));
+    }
+
+    @Test
+    public void setTrace_shouldSetHasBearing() throws Exception {
+        mockEngine.setTrace(getTestGpxTrace());
+        mockEngine.setRequest(LocationRequest.create().setFastestInterval(0));
+        Thread.sleep(100);
+        ShadowLooper.runUiThreadTasks();
+        assertThat(callback.locations.get(0).hasBearing()).isFalse();
+        assertThat(callback.locations.get(1).hasBearing()).isTrue();
+        assertThat(callback.locations.get(2).hasBearing()).isTrue();
+    }
+
+    @Test
     public void setTrace_shouldRespectFastestInterval() throws Exception {
         mockEngine.setTrace(getTestGpxTrace());
-        mockEngine.setRequest(LocationRequest.create().setFastestInterval(1000));
-        Thread.sleep(1000);
+        mockEngine.setRequest(LocationRequest.create().setFastestInterval(100));
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(callback.locations).hasSize(1);
-        Thread.sleep(1000);
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(callback.locations).hasSize(2);
-        Thread.sleep(1000);
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(callback.locations).hasSize(3);
     }
@@ -93,12 +117,12 @@ public class MockEngineTest {
     @Test
     public void disable_shouldCancelTraceReplay() throws Exception {
         mockEngine.setTrace(getTestGpxTrace());
-        mockEngine.setRequest(LocationRequest.create().setFastestInterval(1000));
-        Thread.sleep(1000);
+        mockEngine.setRequest(LocationRequest.create().setFastestInterval(100));
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(callback.locations).hasSize(1);
         mockEngine.disable();
-        Thread.sleep(1000);
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(callback.locations).hasSize(1);
     }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/MockEngineTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/MockEngineTest.java
@@ -7,7 +7,6 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -50,11 +49,11 @@ public class MockEngineTest {
         assertThat(callback.lastLocation).isEqualTo(mockLocation);
     }
 
-    @Test @Ignore("Find a better way to test this without Thread.sleep()")
+    @Test
     public void setTrace_shouldReportEachLocation() throws Exception {
         mockEngine.setTrace(getTestGpxTrace());
         mockEngine.setRequest(LocationRequest.create().setFastestInterval(0));
-        Thread.sleep(1000);
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(callback.locations).hasSize(3);
         assertThat(callback.locations.get(0).getLatitude()).isEqualTo(0.0);
@@ -65,11 +64,11 @@ public class MockEngineTest {
         assertThat(callback.locations.get(2).getLongitude()).isEqualTo(2.1);
     }
 
-    @Test @Ignore("Find a better way to test this without Thread.sleep()")
+    @Test
     public void setTrace_shouldReportSpeed() throws Exception {
         mockEngine.setTrace(getTestGpxTrace());
         mockEngine.setRequest(LocationRequest.create().setFastestInterval(0));
-        Thread.sleep(1000);
+        Thread.sleep(100);
         ShadowLooper.runUiThreadTasks();
         assertThat(callback.locations.get(0).getSpeed()).isEqualTo(10f);
         assertThat(callback.locations.get(1).getSpeed()).isEqualTo(20f);
@@ -117,7 +116,7 @@ public class MockEngineTest {
 
     class TestCallback implements LocationEngine.Callback {
         private Location lastLocation;
-        private ArrayList<Location> locations = new ArrayList<Location>();
+        private ArrayList<Location> locations = new ArrayList<>();
 
         @Override
         public void reportLocation(Location location) {


### PR DESCRIPTION
Adds bearing to mock locations emitted by GPX replay. Uses previous and current coordinates to calculate approximate value.

Testing this feature enabled by Robolectric upgrade to fix thread scheduler problem that was causing mock locations to be delivered in reverse order when posted to main thread handler.

Updates sample app to display bearing value.

Closes #36 