### PR TITLE
Minimum SDK 15

### DIFF
--- a/lost/build.gradle
+++ b/lost/build.gradle
@@ -29,7 +29,7 @@ android {
   buildToolsVersion "21.0.2"
 
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion 15
     targetSdkVersion 21
   }
 


### PR DESCRIPTION
Changes minimum SDK from 21 to 15 in library and sample app to allow LOST to be included in projects that target older versions of Android.

Tested both LOST Sample and EraserMap on Galaxy S2 running Android 4.0.4 and encountered no issues.