### PR TITLE
Update minimum SDK in sample app

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 test:
   override:
-    - ./gradlew
+    - ./gradlew --refresh-dependencies
 
 deployment:
   master:

--- a/lost-sample/build.gradle
+++ b/lost-sample/build.gradle
@@ -31,7 +31,7 @@ android {
 
   defaultConfig {
     applicationId "com.example.lost"
-    minSdkVersion 21
+    minSdkVersion 15
     targetSdkVersion 21
     versionCode 1
     versionName "1.0"

--- a/lost/build.gradle
+++ b/lost/build.gradle
@@ -29,7 +29,7 @@ android {
   buildToolsVersion "21.0.2"
 
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion 15
     targetSdkVersion 21
   }
 


### PR DESCRIPTION
Depends on #42 since the library snapshot must be deployed before sample app can successfully build.