### PR TITLE
Remove extra manifest permissions

### DIFF
--- a/lost-sample/src/main/AndroidManifest.xml
+++ b/lost-sample/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.lost">
 
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application

--- a/lost/src/main/AndroidManifest.xml
+++ b/lost/src/main/AndroidManifest.xml
@@ -3,15 +3,7 @@
     package="com.mapzen.lost">
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <!-- ANDROID_MOCK_LOCATION -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-feature
         android:name="android.hardware.sensor.accelerometer"


### PR DESCRIPTION
Library permissions are now only `ACCESS_COARSE_LOCATION` and `ACCESS_FINE_LOCATION`.

Sample application adds `READ_EXTERNAL_STORAGE` to allow mock GPX trace replay from SD card.