### PR TITLE
Dont remove listeners on setMockMode

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/api/LostApiClient.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LostApiClient.java
@@ -12,6 +12,8 @@ public interface LostApiClient {
 
     public boolean isConnected();
 
+    public int numberOfListeners();
+
     public static final class Builder {
         private final Context context;
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/LostApiClient.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LostApiClient.java
@@ -12,8 +12,6 @@ public interface LostApiClient {
 
     public boolean isConnected();
 
-    public int numberOfListeners();
-
     public static final class Builder {
         private final Context context;
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -80,7 +80,7 @@ public class FusedLocationProviderApiImpl implements
 
     private void toggleMockMode() {
         mockMode = !mockMode;
-        shutdownAllEngines();
+        toggleAllEngines();
         if (mockMode) {
             lastLocationEngine = new MockEngine(context, null);
         } else {
@@ -121,6 +121,14 @@ public class FusedLocationProviderApiImpl implements
 
     public void shutdown() {
         shutdownAllEngines();
+    }
+
+    public List<LocationListener> getListeners() {
+        List<LocationListener> listeners = new ArrayList<>();
+        for (LocationEngine engine : engineListeners.keySet()) {
+            listeners.addAll(engineListeners.get(engine));
+        }
+        return listeners;
     }
 
     /**
@@ -180,6 +188,39 @@ public class FusedLocationProviderApiImpl implements
             }
         }
         return null;
+    }
+
+    private void toggleAllEngines() {
+        HashMap<LocationRequest, LocationEngine> enginesToAdd = new HashMap<>();
+        HashMap<LocationEngine, List<LocationListener>> listenersToAdd = new HashMap<>();
+        for (LocationRequest request : locationEngines.keySet()) {
+            LocationEngine existing = locationEngines.get(request);
+            LocationEngine engineToAdd;
+            if (mockMode) {
+                engineToAdd = new MockEngine(context, this);
+            } else {
+                engineToAdd = new FusionEngine(context, this);
+            }
+            enginesToAdd.put(request, engineToAdd);
+
+            List<LocationListener> listeners = engineListeners.get(existing);
+            listenersToAdd.put(engineToAdd, listeners);
+
+            //Cleanup listeners
+            engineListeners.remove(existing);
+            existing.setRequest(null);
+        }
+        //Cleanup engines
+        locationEngines.clear();
+
+        //Now add new engines/listeners
+        for (LocationRequest request : enginesToAdd.keySet()) {
+            LocationEngine engine = enginesToAdd.get(request);
+            List<LocationListener> listeners = listenersToAdd.get(engine);
+            for (LocationListener listener : listeners) {
+                requestLocationUpdates(request, listener);
+            }
+        }
     }
 
     private void shutdownAllEngines() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -217,8 +217,10 @@ public class FusedLocationProviderApiImpl implements
         for (LocationRequest request : enginesToAdd.keySet()) {
             LocationEngine engine = enginesToAdd.get(request);
             List<LocationListener> listeners = listenersToAdd.get(engine);
-            for (LocationListener listener : listeners) {
-                requestLocationUpdates(request, listener);
+            if (listeners != null) {
+                for (LocationListener listener : listeners) {
+                    requestLocationUpdates(request, listener);
+                }
             }
         }
     }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -43,9 +43,12 @@ public class FusedLocationProviderApiImpl implements
 
     @Override
     public void requestLocationUpdates(LocationRequest request, LocationListener listener) {
+        LocationEngine existing = locationEngines.get(request);
         LocationEngine engine = locationEngineForRequest(request);
         addListenerForEngine(engine, listener);
-        engine.setRequest(request);
+        if (existing == null) {
+            engine.setRequest(request);
+        }
     }
 
     @Override
@@ -227,7 +230,7 @@ public class FusedLocationProviderApiImpl implements
     }
 
     @VisibleForTesting
-    public List<LocationListener> getListeners() {
+    List<LocationListener> getListeners() {
         List<LocationListener> listeners = new ArrayList<>();
         for (LocationEngine engine : engineListeners.keySet()) {
             listeners.addAll(engineListeners.get(engine));

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -8,6 +8,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.location.Location;
 import android.os.Looper;
+import android.support.annotation.VisibleForTesting;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -123,14 +124,6 @@ public class FusedLocationProviderApiImpl implements
         shutdownAllEngines();
     }
 
-    public List<LocationListener> getListeners() {
-        List<LocationListener> listeners = new ArrayList<>();
-        for (LocationEngine engine : engineListeners.keySet()) {
-            listeners.addAll(engineListeners.get(engine));
-        }
-        return listeners;
-    }
-
     /**
      * First checks for an existing {@link LocationEngine} given a request. Creates a new one if
      * none exist.
@@ -231,5 +224,14 @@ public class FusedLocationProviderApiImpl implements
             engine.setRequest(null);
         }
         locationEngines.clear();
+    }
+
+    @VisibleForTesting
+    public List<LocationListener> getListeners() {
+        List<LocationListener> listeners = new ArrayList<>();
+        for (LocationEngine engine : engineListeners.keySet()) {
+            listeners.addAll(engineListeners.get(engine));
+        }
+        return listeners;
     }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
@@ -41,4 +41,14 @@ public class LostApiClientImpl implements LostApiClient {
     public boolean isConnected() {
         return LocationServices.FusedLocationApi != null && LocationServices.GeofencingApi != null;
     }
+
+    @Override
+    public int numberOfListeners() {
+        if (LocationServices.FusedLocationApi == null) {
+            return 0;
+        }
+        FusedLocationProviderApiImpl api
+            = (FusedLocationProviderApiImpl) LocationServices.FusedLocationApi;
+        return api.getListeners().size();
+    }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
@@ -41,14 +41,5 @@ public class LostApiClientImpl implements LostApiClient {
     public boolean isConnected() {
         return LocationServices.FusedLocationApi != null && LocationServices.GeofencingApi != null;
     }
-
-    @Override
-    public int numberOfListeners() {
-        if (LocationServices.FusedLocationApi == null) {
-            return 0;
-        }
-        FusedLocationProviderApiImpl api
-            = (FusedLocationProviderApiImpl) LocationServices.FusedLocationApi;
-        return api.getListeners().size();
-    }
+    
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -203,12 +203,12 @@ public class FusedLocationProviderApiImplTest {
     }
 
     @Test
-    public void setMockMode_shouldToggleAllListenersWhenTrue() throws Exception {
+    public void setMockMode_shouldUnregisterAllListenersWhenTrue() throws Exception {
         TestLocationListener listener = new TestLocationListener();
         LocationRequest request = LocationRequest.create();
         api.requestLocationUpdates(request, listener);
         api.setMockMode(true);
-        assertThat(api.getListeners()).hasSize(1);
+        assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isEmpty();
     }
 
     @Test
@@ -218,6 +218,16 @@ public class FusedLocationProviderApiImplTest {
         api.setMockMode(true);
         api.requestLocationUpdates(request, listener);
         api.setMockMode(false);
+        api.requestLocationUpdates(request, listener);
+        assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).hasSize(4);
+    }
+
+    @Test
+    public void setMockMode_shouldToggleEngines() {
+        TestLocationListener listener = new TestLocationListener();
+        LocationRequest request = LocationRequest.create();
+        api.requestLocationUpdates(request, listener);
+        api.setMockMode(true);
         api.requestLocationUpdates(request, listener);
         assertThat(api.getListeners()).hasSize(2);
     }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -203,12 +203,12 @@ public class FusedLocationProviderApiImplTest {
     }
 
     @Test
-    public void setMockMode_shouldUnregisterAllListenersWhenTrue() throws Exception {
+    public void setMockMode_shouldToggleAllListenersWhenTrue() throws Exception {
         TestLocationListener listener = new TestLocationListener();
         LocationRequest request = LocationRequest.create();
         api.requestLocationUpdates(request, listener);
         api.setMockMode(true);
-        assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isEmpty();
+        assertThat(api.getListeners()).hasSize(1);
     }
 
     @Test
@@ -219,7 +219,7 @@ public class FusedLocationProviderApiImplTest {
         api.requestLocationUpdates(request, listener);
         api.setMockMode(false);
         api.requestLocationUpdates(request, listener);
-        assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).hasSize(2);
+        assertThat(api.getListeners()).hasSize(2);
     }
 
     @Test

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -219,7 +219,7 @@ public class FusedLocationProviderApiImplTest {
         api.requestLocationUpdates(request, listener);
         api.setMockMode(false);
         api.requestLocationUpdates(request, listener);
-        assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).hasSize(4);
+        assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).hasSize(2);
     }
 
     @Test


### PR DESCRIPTION
- Instead of shutting down all engines when mock mode is toggled on/off, toggle them so that `MockEngine`s are created for existing listeners when mock mode enabled
- Add method to get the number of listeners so that shared instances of `LostApiClient` can know whether or not they should call `disconnect`