### PR TITLE
Enforce 1-1 request/listener relationship

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -10,9 +10,8 @@ import android.location.Location;
 import android.os.Looper;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.Map;
 
 /**
  * Implementation of the {@link FusedLocationProviderApi}.
@@ -21,33 +20,25 @@ public class FusedLocationProviderApiImpl implements
         FusedLocationProviderApi, LocationEngine.Callback {
 
     private final Context context;
-    private HashMap<LocationRequest, LocationEngine> locationEngines;
-    private HashMap<LocationEngine, List<LocationListener>> engineListeners;
-    private LocationEngine lastLocationEngine;
     private boolean mockMode;
-    private File mockTraceFile;
-    private Location mockLocation;
+    private LocationEngine locationEngine;
+    private Map<LocationListener, LocationRequest> listenerToRequest;
 
     public FusedLocationProviderApiImpl(Context context) {
         this.context = context;
-        locationEngines = new HashMap<>();
-        engineListeners = new HashMap<>();
-        lastLocationEngine = new FusionEngine(context, null);
+        locationEngine = new FusionEngine(context, this);
+        listenerToRequest = new HashMap<>();
     }
 
     @Override
     public Location getLastLocation() {
-        return lastLocationEngine.getLastLocation();
+        return locationEngine.getLastLocation();
     }
 
     @Override
     public void requestLocationUpdates(LocationRequest request, LocationListener listener) {
-        LocationEngine existing = locationEngines.get(request);
-        LocationEngine engine = locationEngineForRequest(request);
-        addListenerForEngine(engine, listener);
-        if (existing == null) {
-            engine.setRequest(request);
-        }
+        listenerToRequest.put(listener, request);
+        locationEngine.setRequest(request);
     }
 
     @Override
@@ -63,9 +54,9 @@ public class FusedLocationProviderApiImpl implements
 
     @Override
     public void removeLocationUpdates(LocationListener listener) {
-        LocationEngine engine = removeListenerFromEngine(listener);
-        if (engine != null) {
-            checkShutdownEngine(engine);
+        listenerToRequest.remove(listener);
+        if (listenerToRequest.isEmpty()) {
+            locationEngine.setRequest(null);
         }
     }
 
@@ -83,181 +74,61 @@ public class FusedLocationProviderApiImpl implements
 
     private void toggleMockMode() {
         mockMode = !mockMode;
-        toggleAllEngines();
+        locationEngine.setRequest(null);
         if (mockMode) {
-            lastLocationEngine = new MockEngine(context, null);
+            locationEngine = new MockEngine(context, this);
         } else {
-            lastLocationEngine = new FusionEngine(context, null);
+            locationEngine = new FusionEngine(context, this);
         }
     }
 
     @Override
     public void setMockLocation(Location mockLocation) {
-        this.mockLocation = mockLocation;
         if (mockMode) {
-            ((MockEngine) lastLocationEngine).setLocation(mockLocation);
-            for (LocationEngine engine : locationEngines.values()) {
-                ((MockEngine) engine).setLocation(mockLocation);
-            }
+            ((MockEngine) locationEngine).setLocation(mockLocation);
         }
     }
 
     @Override
     public void setMockTrace(File file) {
-        this.mockTraceFile = file;
         if (mockMode) {
-            for (LocationEngine engine : locationEngines.values()) {
-                ((MockEngine) engine).setTrace(file);
-            }
+            ((MockEngine) locationEngine).setTrace(file);
         }
     }
 
     @Override
     public boolean isProviderEnabled(String provider) {
-        return lastLocationEngine.isProviderEnabled(provider);
+        return locationEngine.isProviderEnabled(provider);
     }
 
     @Override
-    public void reportLocation(LocationEngine engine, Location location) {
-        final List<LocationListener> listeners = engineListeners.get(engine);
-        if (listeners != null) {
-            for (LocationListener listener : listeners) {
-                listener.onLocationChanged(location);
-            }
+    public void reportLocation(Location location) {
+        for (LocationListener listener : listenerToRequest.keySet()) {
+            listener.onLocationChanged(location);
         }
     }
 
     @Override
-    public void reportProviderDisabled(LocationEngine engine, String provider) {
-        final List<LocationListener> listeners = engineListeners.get(engine);
-        if (listeners != null) {
-            for (LocationListener listener : listeners) {
-                listener.onProviderDisabled(provider);
-            }
+    public void reportProviderDisabled(String provider) {
+        for (LocationListener listener : listenerToRequest.keySet()) {
+            listener.onProviderDisabled(provider);
         }
     }
 
     @Override
-    public void reportProviderEnabled(LocationEngine engine, String provider) {
-        final List<LocationListener> listeners = engineListeners.get(engine);
-        if (listeners != null) {
-            for (LocationListener listener : listeners) {
-                listener.onProviderEnabled(provider);
-            }
+    public void reportProviderEnabled(String provider) {
+        for (LocationListener listener : listenerToRequest.keySet()) {
+            listener.onProviderEnabled(provider);
         }
     }
 
     public void shutdown() {
-        shutdownAllEngines();
+        listenerToRequest.clear();
+        locationEngine.setRequest(null);
     }
 
-    /**
-     * First checks for an existing {@link LocationEngine} given a request. Creates a new one if
-     * none exist.
-     * @param request
-     * @return
-     */
-    private LocationEngine locationEngineForRequest(LocationRequest request) {
-        LocationEngine existing = locationEngines.get(request);
-        if (existing == null) {
-            if (mockMode) {
-                existing = new MockEngine(context, this);
-                MockEngine existingMock = (MockEngine) existing;
-                existingMock.setTrace(mockTraceFile);
-                if (mockLocation != null) {
-                    existingMock.setLocation(mockLocation);
-                }
-            } else {
-                existing = new FusionEngine(context, this);
-            }
-            locationEngines.put(request, existing);
-        }
-        return existing;
+    public Map<LocationListener, LocationRequest> getListeners() {
+        return listenerToRequest;
     }
 
-    private void checkShutdownEngine(LocationEngine engine) {
-        if (engineListeners.get(engine) == null) {
-            engine.setRequest(null);
-        }
-    }
-
-    private void addListenerForEngine(LocationEngine engine, LocationListener listener) {
-        List existing = engineListeners.get(engine);
-        if (existing == null) {
-            existing = new ArrayList();
-            engineListeners.put(engine, existing);
-        }
-        existing.add(listener);
-    }
-
-    /**
-     * Removes {@link LocationListener} from map of LocationEngine/LocationListeners and
-     * returns the {@link LocationEngine} that the listner was removed from
-     * @param listener
-     * @return
-     */
-    private LocationEngine removeListenerFromEngine(LocationListener listener) {
-        for (LocationEngine engine : engineListeners.keySet()) {
-            List<LocationListener> listeners = engineListeners.get(engine);
-            if (listeners.contains(listener)) {
-                listeners.remove(listener);
-                if (listeners.isEmpty()) {
-                    engineListeners.remove(engine);
-                }
-                return engine;
-            }
-        }
-        return null;
-    }
-
-    private void toggleAllEngines() {
-        HashMap<LocationRequest, LocationEngine> enginesToAdd = new HashMap<>();
-        HashMap<LocationEngine, List<LocationListener>> listenersToAdd = new HashMap<>();
-        for (LocationRequest request : locationEngines.keySet()) {
-            LocationEngine existing = locationEngines.get(request);
-            LocationEngine engineToAdd;
-            if (mockMode) {
-                engineToAdd = new MockEngine(context, this);
-            } else {
-                engineToAdd = new FusionEngine(context, this);
-            }
-            enginesToAdd.put(request, engineToAdd);
-
-            List<LocationListener> listeners = engineListeners.get(existing);
-            listenersToAdd.put(engineToAdd, listeners);
-
-            //Cleanup listeners
-            engineListeners.remove(existing);
-            existing.setRequest(null);
-        }
-        //Cleanup engines
-        locationEngines.clear();
-
-        //Now add new engines/listeners
-        for (LocationRequest request : enginesToAdd.keySet()) {
-            LocationEngine engine = enginesToAdd.get(request);
-            List<LocationListener> listeners = listenersToAdd.get(engine);
-            if (listeners != null) {
-                for (LocationListener listener : listeners) {
-                    requestLocationUpdates(request, listener);
-                }
-            }
-        }
-    }
-
-    private void shutdownAllEngines() {
-        for (LocationEngine engine : locationEngines.values()) {
-            engineListeners.remove(engine);
-            engine.setRequest(null);
-        }
-        locationEngines.clear();
-    }
-
-    List<LocationListener> getListeners() {
-        List<LocationListener> listeners = new ArrayList<>();
-        for (LocationEngine engine : engineListeners.keySet()) {
-            listeners.addAll(engineListeners.get(engine));
-        }
-        return listeners;
-    }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
@@ -78,22 +78,24 @@ public class FusionEngine extends LocationEngine implements LocationListener {
 
     @Override
     protected void enable() {
-        switch (getRequest().getPriority()) {
-            case LocationRequest.PRIORITY_HIGH_ACCURACY:
-                enableGps();
-                enableNetwork();
-                break;
-            case LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY:
-                enableNetwork();
-                break;
-            case LocationRequest.PRIORITY_LOW_POWER:
-                enableNetwork();
-                break;
-            case LocationRequest.PRIORITY_NO_POWER:
-                enablePassive();
-                break;
-            default:
-                break;
+        for (LocationRequest request : getRequest().getRequests()) {
+            switch (request.getPriority()) {
+                case LocationRequest.PRIORITY_HIGH_ACCURACY:
+                    enableGps(request);
+                    enableNetwork(request);
+                    break;
+                case LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY:
+                    enableNetwork(request);
+                    break;
+                case LocationRequest.PRIORITY_LOW_POWER:
+                    enableNetwork(request);
+                    break;
+                case LocationRequest.PRIORITY_NO_POWER:
+                    enablePassive(request);
+                    break;
+                default:
+                    break;
+            }
         }
     }
 
@@ -104,33 +106,33 @@ public class FusionEngine extends LocationEngine implements LocationListener {
         }
     }
 
-    private void enableGps() {
+    private void enableGps(LocationRequest request) {
         try {
             locationManager.requestLocationUpdates(GPS_PROVIDER,
-                    getRequest().getFastestInterval(),
-                    getRequest().getSmallestDisplacement(),
+                    request.getFastestInterval(),
+                    request.getSmallestDisplacement(),
                     this);
         } catch (IllegalArgumentException e) {
             Log.e(TAG, "Unable to register for GPS updates.", e);
         }
     }
 
-    private void enableNetwork() {
+    private void enableNetwork(LocationRequest request) {
         try {
             locationManager.requestLocationUpdates(NETWORK_PROVIDER,
-                    getRequest().getFastestInterval(),
-                    getRequest().getSmallestDisplacement(),
+                    request.getFastestInterval(),
+                    request.getSmallestDisplacement(),
                     this);
         } catch (IllegalArgumentException e) {
             Log.e(TAG, "Unable to register for network updates.", e);
         }
     }
 
-    private void enablePassive() {
+    private void enablePassive(LocationRequest request) {
         try {
             locationManager.requestLocationUpdates(PASSIVE_PROVIDER,
-                    getRequest().getFastestInterval(),
-                    getRequest().getSmallestDisplacement(),
+                    request.getFastestInterval(),
+                    request.getSmallestDisplacement(),
                     this);
         } catch (IllegalArgumentException e) {
             Log.e(TAG, "Unable to register for passive updates.", e);
@@ -142,12 +144,12 @@ public class FusionEngine extends LocationEngine implements LocationListener {
         if (GPS_PROVIDER.equals(location.getProvider())) {
             gpsLocation = location;
             if (getCallback() != null && isBetterThan(gpsLocation, networkLocation)) {
-                getCallback().reportLocation(this, location);
+                getCallback().reportLocation(location);
             }
         } else if (NETWORK_PROVIDER.equals(location.getProvider())) {
             networkLocation = location;
             if (getCallback() != null && isBetterThan(networkLocation, gpsLocation)) {
-                getCallback().reportLocation(this, location);
+                getCallback().reportLocation(location);
             }
         }
     }
@@ -160,7 +162,7 @@ public class FusionEngine extends LocationEngine implements LocationListener {
     public void onProviderEnabled(String provider) {
         final Callback callback = getCallback();
         if (callback != null) {
-            callback.reportProviderEnabled(this, provider);
+            callback.reportProviderEnabled(provider);
         }
     }
 
@@ -168,7 +170,7 @@ public class FusionEngine extends LocationEngine implements LocationListener {
     public void onProviderDisabled(String provider) {
         final Callback callback = getCallback();
         if (callback != null) {
-            callback.reportProviderDisabled(this, provider);
+            callback.reportProviderDisabled(provider);
         }
     }
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LocationEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LocationEngine.java
@@ -12,11 +12,12 @@ import android.location.Location;
 public abstract class LocationEngine {
     private final Context context;
     private final Callback callback;
-    private LocationRequest request;
+    private LocationRequestUnbundled request;
 
     public LocationEngine(Context context, Callback callback) {
         this.context = context;
         this.callback = callback;
+        request = new LocationRequestUnbundled();
     }
 
     /**
@@ -33,10 +34,11 @@ public abstract class LocationEngine {
      * @param request Valid location request to enable or {@code null} to disable.
      */
     public void setRequest(LocationRequest request) {
-        this.request = request;
         if (request != null) {
+            this.request.addRequest(request);
             enable();
         } else {
+            this.request.removeAllRequests();
             disable();
         }
     }
@@ -61,13 +63,13 @@ public abstract class LocationEngine {
         return callback;
     }
 
-    protected LocationRequest getRequest() {
+    protected LocationRequestUnbundled getRequest() {
         return request;
     }
 
     public interface Callback {
-        void reportLocation(LocationEngine engine, Location location);
-        void reportProviderDisabled(LocationEngine engine, String provider);
-        void reportProviderEnabled(LocationEngine engine, String provider);
+        void reportLocation(Location location);
+        void reportProviderDisabled(String provider);
+        void reportProviderEnabled(String provider);
     }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LocationRequestUnbundled.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LocationRequestUnbundled.java
@@ -1,0 +1,35 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LocationRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ */
+public class LocationRequestUnbundled {
+
+  private List<LocationRequest> requests = new ArrayList<>();
+  private long fastestInterval = Long.MAX_VALUE;
+
+  public void addRequest(LocationRequest request) {
+    if (request.getFastestInterval() < fastestInterval) {
+      fastestInterval = request.getFastestInterval();
+    }
+    requests.add(request);
+  }
+
+  public void removeAllRequests() {
+    fastestInterval = Long.MAX_VALUE;
+    requests.clear();
+  }
+
+  public List<LocationRequest> getRequests() {
+    return requests;
+  }
+
+  public long getFastestInterval() {
+    return fastestInterval;
+  }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/internal/MockEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/MockEngine.java
@@ -68,7 +68,7 @@ public class MockEngine extends LocationEngine {
     public void setLocation(Location location) {
         this.location = location;
         if (getCallback() != null) {
-            getCallback().reportLocation(this, location);
+            getCallback().reportLocation(location);
         }
     }
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -228,7 +228,9 @@ public class FusedLocationProviderApiImplTest {
         LocationRequest request = LocationRequest.create();
         api.requestLocationUpdates(request, listener);
         api.setMockMode(true);
-        api.requestLocationUpdates(request, listener);
+        TestLocationListener listener2 = new TestLocationListener();
+        LocationRequest request2 = LocationRequest.create();
+        api.requestLocationUpdates(request2, listener2);
         assertThat(api.getListeners()).hasSize(2);
     }
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusionEngineTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusionEngineTest.java
@@ -396,16 +396,16 @@ public class FusionEngineTest {
         private Location location;
 
         @Override
-        public void reportLocation(LocationEngine engine, Location location) {
+        public void reportLocation(Location location) {
             this.location = location;
         }
 
         @Override
-        public void reportProviderDisabled(LocationEngine engine, String provider) {
+        public void reportProviderDisabled(String provider) {
         }
 
         @Override
-        public void reportProviderEnabled(LocationEngine engine, String provider) {
+        public void reportProviderEnabled(String provider) {
         }
     }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/MockEngineTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/MockEngineTest.java
@@ -170,17 +170,17 @@ public class MockEngineTest {
         private ArrayList<Location> locations = new ArrayList<>();
 
         @Override
-        public void reportLocation(LocationEngine engine, Location location) {
+        public void reportLocation(Location location) {
             lastLocation = location;
             locations.add(location);
         }
 
         @Override
-        public void reportProviderDisabled(LocationEngine engine, String provider) {
+        public void reportProviderDisabled(String provider) {
         }
 
         @Override
-        public void reportProviderEnabled(LocationEngine engine, String provider) {
+        public void reportProviderEnabled(String provider) {
         }
 
         public void reset() {


### PR DESCRIPTION
- Use single `LocationEngine` in `FusedLocationProviderApiImpl`
- Bundle `LocationRequest` into `LocationRequestUnbundled`

As a result of these changes, listeners may receive results that are more/less accurate than requested but I think this is okay given that the LocationRequest documentation says this:
"All location requests are considered hints, and you may receive locations that are more/less accurate, and faster/slower than requested."

https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest

Closes #57 
