### PR TITLE
Remove location permissions

### DIFF
--- a/lost-sample/src/main/AndroidManifest.xml
+++ b/lost-sample/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.lost">
 
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.BLUETOOTH"/>
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>

--- a/lost/src/main/AndroidManifest.xml
+++ b/lost/src/main/AndroidManifest.xml
@@ -2,9 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mapzen.lost">
 
-  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-
   <uses-feature
       android:name="android.hardware.sensor.accelerometer"
       android:required="false"/>

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -1,7 +1,6 @@
 package com.mapzen.android.lost.api;
 
 import android.app.PendingIntent;
-import android.content.Intent;
 import android.location.Location;
 import android.os.Looper;
 import android.support.annotation.RequiresPermission;
@@ -14,8 +13,8 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 public interface FusedLocationProviderApi {
 
   /**
-   * @deprecated Use {@link LocationResult#hasResult(Intent)} and
-   * {@link LocationResult#extractResult(Intent)}.
+   * @deprecated Use {@link LocationResult#hasResult(android.content.Intent)} and
+   * {@link LocationResult#extractResult(android.content.Intent)}.
    */
   @Deprecated String KEY_LOCATION_CHANGED = "com.mapzen.android.lost.LOCATION";
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -21,26 +21,23 @@ public interface FusedLocationProviderApi {
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   Location getLastLocation();
 
-  void removeLocationUpdates(LocationListener listener);
-
-  void removeLocationUpdates(PendingIntent callbackIntent);
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
+  void requestLocationUpdates(LocationRequest request, LocationListener listener);
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   void requestLocationUpdates(LocationRequest request, LocationListener listener, Looper looper);
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  void requestLocationUpdates(LocationRequest request, LocationListener listener);
-
-  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   void requestLocationUpdates(LocationRequest request, PendingIntent callbackIntent);
 
-  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  void setMockLocation(Location mockLocation);
+  void removeLocationUpdates(LocationListener listener);
 
-  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
+  void removeLocationUpdates(PendingIntent callbackIntent);
+
   void setMockMode(boolean isMockMode);
 
-  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
+  void setMockLocation(Location mockLocation);
+
   void setMockTrace(final File file);
 
   /**

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -1,6 +1,7 @@
 package com.mapzen.android.lost.api;
 
 import android.app.PendingIntent;
+import android.content.Intent;
 import android.location.Location;
 import android.os.Looper;
 import android.support.annotation.RequiresPermission;
@@ -9,6 +10,10 @@ import java.io.File;
 
 public interface FusedLocationProviderApi {
 
+  /**
+   * @deprecated Use {@link LocationResult#hasResult(Intent)} and
+   * {@link LocationResult#extractResult(Intent)}.
+   */
   @Deprecated String KEY_LOCATION_CHANGED = "com.mapzen.android.lost.LOCATION";
 
   @RequiresPermission(anyOf = {
@@ -50,5 +55,9 @@ public interface FusedLocationProviderApi {
   })
   void setMockTrace(final File file);
 
-  boolean isProviderEnabled(String provider);
+  /**
+   * @deprecated Use {@link SettingsApi#checkLocationSettings(LostApiClient,
+   * LocationSettingsRequest)}.
+   */
+  @Deprecated boolean isProviderEnabled(String provider);
 }

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -3,6 +3,7 @@ package com.mapzen.android.lost.api;
 import android.app.PendingIntent;
 import android.location.Location;
 import android.os.Looper;
+import android.support.annotation.RequiresPermission;
 
 import java.io.File;
 
@@ -10,22 +11,43 @@ public interface FusedLocationProviderApi {
 
   @Deprecated String KEY_LOCATION_CHANGED = "com.mapzen.android.lost.LOCATION";
 
+  @RequiresPermission(anyOf = {
+      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
+  })
   Location getLastLocation();
 
   void removeLocationUpdates(LocationListener listener);
 
   void removeLocationUpdates(PendingIntent callbackIntent);
 
+  @RequiresPermission(anyOf = {
+      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
+  })
   void requestLocationUpdates(LocationRequest request, LocationListener listener, Looper looper);
 
+  @RequiresPermission(anyOf = {
+      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
+  })
   void requestLocationUpdates(LocationRequest request, LocationListener listener);
 
+  @RequiresPermission(anyOf = {
+      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
+  })
   void requestLocationUpdates(LocationRequest request, PendingIntent callbackIntent);
 
+  @RequiresPermission(anyOf = {
+      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
+  })
   void setMockLocation(Location mockLocation);
 
+  @RequiresPermission(anyOf = {
+      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
+  })
   void setMockMode(boolean isMockMode);
 
+  @RequiresPermission(anyOf = {
+      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
+  })
   void setMockTrace(final File file);
 
   boolean isProviderEnabled(String provider);

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -8,6 +8,9 @@ import android.support.annotation.RequiresPermission;
 
 import java.io.File;
 
+import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
+import static android.Manifest.permission.ACCESS_FINE_LOCATION;
+
 public interface FusedLocationProviderApi {
 
   /**
@@ -16,43 +19,29 @@ public interface FusedLocationProviderApi {
    */
   @Deprecated String KEY_LOCATION_CHANGED = "com.mapzen.android.lost.LOCATION";
 
-  @RequiresPermission(anyOf = {
-      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
-  })
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   Location getLastLocation();
 
   void removeLocationUpdates(LocationListener listener);
 
   void removeLocationUpdates(PendingIntent callbackIntent);
 
-  @RequiresPermission(anyOf = {
-      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
-  })
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   void requestLocationUpdates(LocationRequest request, LocationListener listener, Looper looper);
 
-  @RequiresPermission(anyOf = {
-      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
-  })
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   void requestLocationUpdates(LocationRequest request, LocationListener listener);
 
-  @RequiresPermission(anyOf = {
-      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
-  })
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   void requestLocationUpdates(LocationRequest request, PendingIntent callbackIntent);
 
-  @RequiresPermission(anyOf = {
-      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
-  })
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   void setMockLocation(Location mockLocation);
 
-  @RequiresPermission(anyOf = {
-      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
-  })
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   void setMockMode(boolean isMockMode);
 
-  @RequiresPermission(anyOf = {
-      "android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"
-  })
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   void setMockTrace(final File file);
 
   /**

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
@@ -114,13 +114,13 @@ public class FusionEngine extends LocationEngine implements LocationListener {
     }
   }
 
-  @Override protected void disable() {
+  @Override protected void disable() throws SecurityException {
     if (locationManager != null) {
       locationManager.removeUpdates(this);
     }
   }
 
-  private void enableGps(long interval) {
+  private void enableGps(long interval) throws SecurityException {
     try {
       locationManager.requestLocationUpdates(GPS_PROVIDER, interval, 0, this);
     } catch (IllegalArgumentException e) {
@@ -128,7 +128,7 @@ public class FusionEngine extends LocationEngine implements LocationListener {
     }
   }
 
-  private void enableNetwork(long interval) {
+  private void enableNetwork(long interval) throws SecurityException {
     try {
       locationManager.requestLocationUpdates(NETWORK_PROVIDER, interval, 0, this);
     } catch (IllegalArgumentException e) {
@@ -136,7 +136,7 @@ public class FusionEngine extends LocationEngine implements LocationListener {
     }
   }
 
-  private void enablePassive(long interval) {
+  private void enablePassive(long interval) throws SecurityException {
     try {
       locationManager.requestLocationUpdates(PASSIVE_PROVIDER, interval, 0, this);
     } catch (IllegalArgumentException e) {


### PR DESCRIPTION
### Overview

Permissions `ACCESS_COARSE_LOCATION` and `ACCESS_FINE_LOCATION` should not be included in the LOST library `AndroidManifest.xml`. Instead they should be added as required by client applications based on their API use and additionally requested at runtime on API 23+.

### Proposed Changes

Location permissions have been removed from the library manifest and added to the sample application. `FusedLocationProviderApi` has been modified to use support annotations for `@RequiresPermission`. Finally `throws SecurityException` has been explicitly added to all `FusionEngine` methods that may be rejected if permissions have not been granted by the user.

Closes #75 
