### PR TITLE
64 location availability

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -21,6 +21,8 @@ public interface FusedLocationProviderApi {
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   Location getLastLocation();
 
+  LocationAvailability getLocationAvailability();
+
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   void requestLocationUpdates(LocationRequest request, LocationListener listener);
 
@@ -28,11 +30,16 @@ public interface FusedLocationProviderApi {
   void requestLocationUpdates(LocationRequest request, LocationListener listener, Looper looper);
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
+  void requestLocationUpdates(LocationRequest request, LocationCallback callback, Looper looper);
+
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   void requestLocationUpdates(LocationRequest request, PendingIntent callbackIntent);
 
   void removeLocationUpdates(LocationListener listener);
 
   void removeLocationUpdates(PendingIntent callbackIntent);
+
+  void removeLocationUpdates(LocationCallback callback);
 
   void setMockMode(boolean isMockMode);
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -21,6 +21,7 @@ public interface FusedLocationProviderApi {
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   Location getLastLocation();
 
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   LocationAvailability getLocationAvailability();
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationAvailability.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationAvailability.java
@@ -1,0 +1,94 @@
+package com.mapzen.android.lost.api;
+
+import android.content.Intent;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/**
+ * Status on the availability of location data.
+ *
+ * Delivered from LocationCallback registered via
+ * {@link FusedLocationProviderApi#requestLocationUpdates(
+ * LocationRequest,LocationCallback,android.os.Looper) or from a PendingIntent registered via
+ * {@link FusedLocationProviderApi##requestLocationUpdates(LocationRequest,
+ * android.app.PendingIntent). It is also available on demand via
+ * {@link FusedLocationProviderApi#getLocationAvailability()}.
+ */
+public class LocationAvailability implements Parcelable {
+
+  public static final String EXTRA_LOCATION_AVAILABILITY =
+      "com.mapzen.android.lost.EXTRA_LOCATION_AVAILABILITY";
+
+  boolean locationAvailable = false;
+
+  public LocationAvailability(boolean available) {
+    locationAvailable = available;
+  }
+
+  protected LocationAvailability(Parcel in) {
+    locationAvailable = in.readByte() != 0;
+  }
+
+  public static final Creator<LocationAvailability> CREATOR = new Creator<LocationAvailability>() {
+    @Override public LocationAvailability createFromParcel(Parcel in) {
+      return new LocationAvailability(in);
+    }
+
+    @Override public LocationAvailability[] newArray(int size) {
+      return new LocationAvailability[size];
+    }
+  };
+
+  /**
+   * Extracts the LocationAvailability from an Intent.
+   * @param intent
+   * @return
+   */
+  public static LocationAvailability extractLocationAvailability(Intent intent) {
+    return hasLocationAvailability(intent) ? (LocationAvailability) intent.getExtras()
+        .getParcelable(EXTRA_LOCATION_AVAILABILITY) : null;
+  }
+
+  /**
+   * Returns true if an Intent contains a LocationAvailability.
+   * @param intent
+   * @return
+   */
+  public static boolean hasLocationAvailability(Intent intent) {
+    return intent.hasExtra(EXTRA_LOCATION_AVAILABILITY);
+  }
+
+  /**
+   * Returns true if the device location is known and reasonably up to date within the hints
+   * requested by the active LocationRequests.
+   * @return
+   */
+  public boolean isLocationAvailable() {
+    return locationAvailable;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    LocationAvailability that = (LocationAvailability) o;
+
+    return locationAvailable == that.locationAvailable;
+  }
+
+  @Override public int hashCode() {
+    return (locationAvailable ? 1 : 0);
+  }
+
+  @Override public int describeContents() {
+    return 0;
+  }
+
+  @Override public void writeToParcel(Parcel dest, int flags) {
+    dest.writeByte((byte) (locationAvailable ? 1 : 0));
+  }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationAvailability.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationAvailability.java
@@ -40,9 +40,10 @@ public class LocationAvailability implements Parcelable {
   };
 
   /**
-   * Extracts the LocationAvailability from an Intent.
-   * @param intent
-   * @return
+   * Extracts the {@link LocationAvailability} from an {@link Intent}.
+   * @param intent an {@link Intent} that may or may not include {@link LocationAvailability}.
+   * @return a {@link LocationAvailability} object, or {@code null} if the given {@link Intent}
+   * does not contain this data.
    */
   public static LocationAvailability extractLocationAvailability(Intent intent) {
     return hasLocationAvailability(intent) ? (LocationAvailability) intent.getExtras()
@@ -50,9 +51,10 @@ public class LocationAvailability implements Parcelable {
   }
 
   /**
-   * Returns true if an Intent contains a LocationAvailability.
-   * @param intent
-   * @return
+   * Returns true if an {@link Intent} contains a {@link LocationAvailability} extra.
+   * @param intent an {@link Intent} that may or may not include {@link LocationAvailability}.
+   * @return whether or not the {@link Intent} has {@link LocationAvailability} extra
+   * {@link LocationAvailability.EXTRA_LOCATION_AVAILABILITY}
    */
   public static boolean hasLocationAvailability(Intent intent) {
     return intent.hasExtra(EXTRA_LOCATION_AVAILABILITY);
@@ -61,7 +63,7 @@ public class LocationAvailability implements Parcelable {
   /**
    * Returns true if the device location is known and reasonably up to date within the hints
    * requested by the active LocationRequests.
-   * @return
+   * @return Whether or not location is available.
    */
   public boolean isLocationAvailable() {
     return locationAvailable;

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationCallback.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationCallback.java
@@ -1,0 +1,23 @@
+package com.mapzen.android.lost.api;
+
+/**
+ * Used for receiving notifications from the FusedLocationProviderApi when the device location has
+ * changed or can no longer be determined. The methods are called if the LocationCallback has been
+ * registered with the location client using the
+ * {@link FusedLocationProviderApi#requestLocationUpdates(LocationRequest, LocationCallback,
+ * android.os.Looper) method.
+ */
+public interface LocationCallback {
+  /**
+   * Called when there is a change in the availability of location data.
+   * @param locationAvailability
+   */
+  void onLocationAvailability(LocationAvailability locationAvailability);
+
+  /**
+   * Called when device location information is available.
+   * @param result
+   */
+  void onLocationResult(LocationResult result);
+
+}

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationCallback.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationCallback.java
@@ -10,13 +10,13 @@ package com.mapzen.android.lost.api;
 public interface LocationCallback {
   /**
    * Called when there is a change in the availability of location data.
-   * @param locationAvailability
+   * @param locationAvailability the current {@link LocationAvailability}
    */
   void onLocationAvailability(LocationAvailability locationAvailability);
 
   /**
    * Called when device location information is available.
-   * @param result
+   * @param result the current {@link LocationResult}
    */
   void onLocationResult(LocationResult result);
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationResult.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationResult.java
@@ -14,7 +14,8 @@ import java.util.List;
  * A data class representing a geographic location result from the fused location provider.
  */
 public final class LocationResult implements Parcelable {
-  static final String EXTRA_LOCATION_RESULT = "com.mapzen.android.lost.EXTRA_LOCATION_RESULT";
+  public static final String EXTRA_LOCATION_RESULT =
+      "com.mapzen.android.lost.EXTRA_LOCATION_RESULT";
 
   private final List<Location> locations;
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -1,6 +1,8 @@
 package com.mapzen.android.lost.internal;
 
 import com.mapzen.android.lost.api.FusedLocationProviderApi;
+import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationCallback;
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LostApiClient;
@@ -77,6 +79,10 @@ public class FusedLocationProviderApiImpl
     return service.getLastLocation();
   }
 
+  @Override public LocationAvailability getLocationAvailability() {
+    return service.getLocationAvailability();
+  }
+
   @Override public void requestLocationUpdates(LocationRequest request, LocationListener listener) {
     service.requestLocationUpdates(request, listener);
   }
@@ -84,6 +90,11 @@ public class FusedLocationProviderApiImpl
   @Override public void requestLocationUpdates(LocationRequest request, LocationListener listener,
       Looper looper) {
     throw new RuntimeException("Sorry, not yet implemented");
+  }
+
+  @Override public void requestLocationUpdates(LocationRequest request, LocationCallback callback,
+      Looper looper) {
+    service.requestLocationUpdates(request, callback, looper);
   }
 
   @Override
@@ -97,6 +108,10 @@ public class FusedLocationProviderApiImpl
 
   @Override public void removeLocationUpdates(PendingIntent callbackIntent) {
     service.removeLocationUpdates(callbackIntent);
+  }
+
+  @Override public void removeLocationUpdates(LocationCallback callback) {
+    service.removeLocationUpdates(callback);
   }
 
   @Override public void setMockMode(boolean isMockMode) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
@@ -1,5 +1,7 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationCallback;
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 
@@ -9,6 +11,7 @@ import android.content.Intent;
 import android.location.Location;
 import android.os.Binder;
 import android.os.IBinder;
+import android.os.Looper;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
@@ -53,6 +56,10 @@ public class FusedLocationProviderService extends Service {
     return serviceImpl.getLastLocation();
   }
 
+  public LocationAvailability getLocationAvailability() {
+    return serviceImpl.getLocationAvailability();
+  }
+
   public void requestLocationUpdates(LocationRequest request, LocationListener listener) {
     serviceImpl.requestLocationUpdates(request, listener);
   }
@@ -61,12 +68,21 @@ public class FusedLocationProviderService extends Service {
     serviceImpl.requestLocationUpdates(request, callbackIntent);
   }
 
+  public void requestLocationUpdates(LocationRequest request, LocationCallback callback,
+      Looper looper) {
+    serviceImpl.requestLocationUpdates(request, callback, looper);
+  }
+
   public void removeLocationUpdates(LocationListener listener) {
     serviceImpl.removeLocationUpdates(listener);
   }
 
   public void removeLocationUpdates(PendingIntent callbackIntent) {
     serviceImpl.removeLocationUpdates(callbackIntent);
+  }
+
+  public void removeLocationUpdates(LocationCallback callback) {
+    serviceImpl.removeLocationUpdates(callback);
   }
 
   public void setMockMode(boolean isMockMode) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
@@ -194,7 +194,12 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
         Context.LOCATION_SERVICE);
     boolean gpsEnabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
     boolean networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
-    return new LocationAvailability(gpsEnabled || networkEnabled);
+    boolean gpsLocationExists = locationManager.getLastKnownLocation(
+        LocationManager.GPS_PROVIDER) != null;
+    boolean networkLocationExists = locationManager.getLastKnownLocation(
+        LocationManager.NETWORK_PROVIDER) != null;
+    return new LocationAvailability((gpsEnabled && gpsLocationExists)
+        || (networkEnabled && networkLocationExists));
   }
 
   private void notifyLocationAvailabilityChanged() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
@@ -1,15 +1,22 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationCallback;
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
+import com.mapzen.android.lost.api.LocationResult;
 
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
+import android.location.LocationManager;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,22 +32,32 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
   private LocationEngine locationEngine;
   private Map<LocationListener, LocationRequest> listenerToRequest;
   private Map<PendingIntent, LocationRequest> intentToRequest;
+  private Map<LocationCallback, LocationRequest> callbackToRequest;
+  private Map<LocationCallback, Looper> callbackToLooper;
 
   public FusedLocationProviderServiceImpl(Context context) {
     this.context = context;
     locationEngine = new FusionEngine(context, this);
     listenerToRequest = new HashMap<>();
     intentToRequest = new HashMap<>();
+    callbackToRequest = new HashMap<>();
+    callbackToLooper = new HashMap<>();
   }
 
   public void shutdown() {
     listenerToRequest.clear();
     intentToRequest.clear();
+    callbackToRequest.clear();
+    callbackToLooper.clear();
     locationEngine.setRequest(null);
   }
 
   public Location getLastLocation() {
     return locationEngine.getLastLocation();
+  }
+
+  public LocationAvailability getLocationAvailability() {
+    return createLocationAvailability();
   }
 
   public void requestLocationUpdates(LocationRequest request, LocationListener listener) {
@@ -53,22 +70,35 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
     locationEngine.setRequest(request);
   }
 
+  public void requestLocationUpdates(LocationRequest request, LocationCallback callback,
+      Looper looper) {
+    callbackToRequest.put(callback, request);
+    callbackToLooper.put(callback, looper);
+    locationEngine.setRequest(request);
+  }
+
   public void removeLocationUpdates(LocationListener listener) {
     listenerToRequest.remove(listener);
-    checkAllListenersAndPendingIntents();
+    checkAllListenersPendingIntentsAndCallbacks();
   }
 
   public void removeLocationUpdates(PendingIntent callbackIntent) {
     intentToRequest.remove(callbackIntent);
-    checkAllListenersAndPendingIntents();
+    checkAllListenersPendingIntentsAndCallbacks();
+  }
+
+  public void removeLocationUpdates(LocationCallback callback) {
+    callbackToRequest.remove(callback);
+    callbackToLooper.remove(callback);
+    checkAllListenersPendingIntentsAndCallbacks();
   }
 
   /**
    * Checks if any listeners or pending intents are still registered for location updates. If not,
    * then shutdown the location engine.
    */
-  private void checkAllListenersAndPendingIntents() {
-    if (listenerToRequest.isEmpty() && intentToRequest.isEmpty()) {
+  private void checkAllListenersPendingIntentsAndCallbacks() {
+    if (listenerToRequest.isEmpty() && intentToRequest.isEmpty() && callbackToRequest.isEmpty()) {
       locationEngine.setRequest(null);
     }
   }
@@ -110,13 +140,30 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
       listener.onLocationChanged(location);
     }
 
+    LocationAvailability availability = createLocationAvailability();
+    ArrayList<Location> locations = new ArrayList<>();
+    locations.add(location);
+    final LocationResult result = LocationResult.create(locations);
+
     for (PendingIntent intent : intentToRequest.keySet()) {
       try {
-        intent.send(context, 0, new Intent().putExtra(
-            KEY_LOCATION_CHANGED, location));
+        Intent toSend = new Intent().putExtra(KEY_LOCATION_CHANGED, location);
+        toSend.putExtra(LocationAvailability.EXTRA_LOCATION_AVAILABILITY, availability);
+        toSend.putExtra(LocationResult.EXTRA_LOCATION_RESULT, result);
+        intent.send(context, 0, toSend);
       } catch (PendingIntent.CanceledException e) {
         Log.e(TAG, "Unable to send pending intent: " + intent);
       }
+    }
+
+    for (final LocationCallback callback : callbackToRequest.keySet()) {
+      Looper looper = callbackToLooper.get(callback);
+      Handler handler = new Handler(looper);
+      handler.post(new Runnable() {
+          @Override public void run() {
+              callback.onLocationResult(result);
+            }
+        });
     }
   }
 
@@ -124,12 +171,14 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
     for (LocationListener listener : listenerToRequest.keySet()) {
       listener.onProviderDisabled(provider);
     }
+    notifyLocationAvailabilityChanged();
   }
 
   public void reportProviderEnabled(String provider) {
     for (LocationListener listener : listenerToRequest.keySet()) {
       listener.onProviderEnabled(provider);
     }
+    notifyLocationAvailabilityChanged();
   }
 
   public Map<LocationListener, LocationRequest> getListeners() {
@@ -138,5 +187,26 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
 
   public Map<PendingIntent, LocationRequest> getPendingIntents() {
     return intentToRequest;
+  }
+
+  private LocationAvailability createLocationAvailability() {
+    LocationManager locationManager = (LocationManager) context.getSystemService(
+        Context.LOCATION_SERVICE);
+    boolean gpsEnabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+    boolean networkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+    return new LocationAvailability(gpsEnabled || networkEnabled);
+  }
+
+  private void notifyLocationAvailabilityChanged() {
+    final LocationAvailability availability = createLocationAvailability();
+    for (final LocationCallback callback : callbackToRequest.keySet()) {
+      Looper looper = callbackToLooper.get(callback);
+      Handler handler = new Handler(looper);
+      handler.post(new Runnable() {
+        @Override public void run() {
+          callback.onLocationAvailability(availability);
+        }
+      });
+    }
   }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -13,6 +13,7 @@ import org.robolectric.annotation.Config;
 import android.app.PendingIntent;
 import android.content.ComponentName;
 import android.location.Location;
+import android.os.Looper;
 
 import java.io.File;
 
@@ -49,6 +50,11 @@ public class FusedLocationProviderApiImplTest {
     verify(service).getLastLocation();
   }
 
+  @Test public void getLocationAvailability_shouldCallService() {
+    api.getLocationAvailability();
+    verify(service).getLocationAvailability();
+  }
+
   @Test public void requestLocationUpdates_listener_shouldCallService() {
     LocationRequest request = LocationRequest.create();
     LocationListener listener = new TestLocationListener();
@@ -59,15 +65,16 @@ public class FusedLocationProviderApiImplTest {
   @Test(expected = RuntimeException.class)
   public void requestLocationUpdates_shouldThrowException() {
     LocationRequest request = LocationRequest.create();
-    api.requestLocationUpdates(request, null, null);
+    TestLocationListener listener = new TestLocationListener();
+    api.requestLocationUpdates(request, listener, null);
   }
 
-  @Test
-  public void requestLocationUpdates_pendingIntent_shouldCallService() {
+  @Test public void requestLocationUpdates_callback_shouldCallService() {
     LocationRequest request = LocationRequest.create();
-    PendingIntent callbackIntent = mock(PendingIntent.class);
-    api.requestLocationUpdates(request, callbackIntent);
-    verify(service).requestLocationUpdates(request, callbackIntent);
+    TestLocationCallback callback = new TestLocationCallback();
+    Looper looper = Looper.myLooper();
+    api.requestLocationUpdates(request, callback, looper);
+    verify(service).requestLocationUpdates(request, callback, looper);
   }
 
   @Test public void removeLocationUpdates_listener_shouldCallService() {
@@ -80,6 +87,12 @@ public class FusedLocationProviderApiImplTest {
     PendingIntent callbackIntent = mock(PendingIntent.class);
     api.removeLocationUpdates(callbackIntent);
     verify(service).removeLocationUpdates(callbackIntent);
+  }
+
+  @Test public void removeLocationUpdates_callback_shouldCallService() {
+    TestLocationCallback callback = new TestLocationCallback();
+    service.removeLocationUpdates(callback);
+    verify(service).removeLocationUpdates(callback);
   }
 
   @Test public void setMockMode_shouldCallService() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
@@ -1,7 +1,9 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.api.LocationAvailability;
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
+import com.mapzen.android.lost.api.LocationResult;
 import com.mapzen.android.lost.api.LocationServices;
 import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.lost.BuildConfig;
@@ -28,11 +30,11 @@ import android.content.Intent;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Environment;
+import android.os.Looper;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -63,8 +65,8 @@ public class FusedLocationProviderServiceImplTest {
   }
 
   private void mockService() {
-    FusedLocationProviderService.FusedLocationProviderBinder stubBinder = mock(
-        FusedLocationProviderService.FusedLocationProviderBinder.class);
+    FusedLocationProviderService.FusedLocationProviderBinder stubBinder =
+        mock(FusedLocationProviderService.FusedLocationProviderBinder.class);
     when(stubBinder.getService()).thenReturn(mock(FusedLocationProviderService.class));
     shadowOf(application).setComponentNameAndServiceForBindService(
         new ComponentName("com.mapzen.lost", "FusedLocationProviderService"), stubBinder);
@@ -206,6 +208,38 @@ public class FusedLocationProviderServiceImplTest {
     assertThat(listener.getMostRecentLocation()).isEqualTo(networkLocation);
   }
 
+  @Test public void requestLocationUpdates_shouldNotifyWithLocationAvailabilityInPendingIntent()
+      throws Exception {
+    Intent intent = new Intent(application, TestService.class);
+    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
+    LocationRequest locationRequest =
+        LocationRequest.create().setPriority(PRIORITY_BALANCED_POWER_ACCURACY);
+    api.requestLocationUpdates(locationRequest, pendingIntent);
+    Location location = new Location(NETWORK_PROVIDER);
+    shadowLocationManager.simulateLocation(location);
+    Intent nextStartedService = ShadowApplication.getInstance().getNextStartedService();
+    assertThat(nextStartedService).isNotNull();
+    assertThat(nextStartedService.getParcelableExtra(
+        LocationAvailability.EXTRA_LOCATION_AVAILABILITY)).isNotNull();
+  }
+
+  @Test public void requestLocationUpdates_shouldNotifyWithLocationResultInPendingIntent()
+      throws Exception {
+    Intent intent = new Intent(application, TestService.class);
+    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
+    LocationRequest locationRequest =
+        LocationRequest.create().setPriority(PRIORITY_BALANCED_POWER_ACCURACY);
+
+    api.requestLocationUpdates(locationRequest, pendingIntent);
+    Location location = new Location(NETWORK_PROVIDER);
+    shadowLocationManager.simulateLocation(location);
+
+    Intent nextStartedService = ShadowApplication.getInstance().getNextStartedService();
+    assertThat(nextStartedService).isNotNull();
+    assertThat(
+        nextStartedService.getParcelableExtra(LocationResult.EXTRA_LOCATION_RESULT)).isNotNull();
+  }
+
   @Test public void removeLocationUpdates_shouldUnregisterAllListeners() throws Exception {
     TestLocationListener listener = new TestLocationListener();
     LocationRequest request = LocationRequest.create();
@@ -339,36 +373,36 @@ public class FusedLocationProviderServiceImplTest {
     TestLocationListener listener = new TestLocationListener();
     LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
     api.requestLocationUpdates(request, listener);
-    listener.isGpsEnabled = true;
+    listener.setIsGpsEnabled(true);
     shadowLocationManager.setProviderEnabled(GPS_PROVIDER, false);
-    assertThat(listener.isGpsEnabled).isFalse();
+    assertThat(listener.getIsGpsEnabled()).isFalse();
   }
 
   @Test public void onProviderDisabled_shouldReportWhenNetworkIsDisabled() throws Exception {
     TestLocationListener listener = new TestLocationListener();
     LocationRequest request = LocationRequest.create();
     api.requestLocationUpdates(request, listener);
-    listener.isNetworkEnabled = true;
+    listener.setIsNetworkEnabled(true);
     shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, false);
-    assertThat(listener.isNetworkEnabled).isFalse();
+    assertThat(listener.getIsNetworkEnabled()).isFalse();
   }
 
   @Test public void onProviderEnabled_shouldReportWhenGpsIsEnabled() throws Exception {
     TestLocationListener listener = new TestLocationListener();
     LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
     api.requestLocationUpdates(request, listener);
-    listener.isGpsEnabled = false;
+    listener.setIsGpsEnabled(false);
     shadowLocationManager.setProviderEnabled(GPS_PROVIDER, true);
-    assertThat(listener.isGpsEnabled).isTrue();
+    assertThat(listener.getIsGpsEnabled()).isTrue();
   }
 
   @Test public void onProviderEnabled_shouldReportWhenNetworkIsEnabled() throws Exception {
     TestLocationListener listener = new TestLocationListener();
     LocationRequest request = LocationRequest.create();
     api.requestLocationUpdates(request, listener);
-    listener.isNetworkEnabled = false;
+    listener.setIsNetworkEnabled(false);
     shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
-    assertThat(listener.isNetworkEnabled).isTrue();
+    assertThat(listener.getIsNetworkEnabled()).isTrue();
   }
 
   private static Location getTestLocation(String provider, float lat, float lng, long time) {
@@ -388,50 +422,6 @@ public class FusedLocationProviderServiceImplTest {
     fileWriter.write(contents);
     fileWriter.close();
     return file;
-  }
-
-  class TestLocationListener implements LocationListener {
-    private ArrayList<Location> locations = new ArrayList<>();
-    private boolean isGpsEnabled = true;
-    private boolean isNetworkEnabled = true;
-
-    @Override public void onLocationChanged(Location location) {
-      locations.add(location);
-    }
-
-    @Override public void onProviderDisabled(String provider) {
-      switch (provider) {
-        case GPS_PROVIDER:
-          isGpsEnabled = false;
-          break;
-        case NETWORK_PROVIDER:
-          isNetworkEnabled = false;
-          break;
-        default:
-          break;
-      }
-    }
-
-    @Override public void onProviderEnabled(String provider) {
-      switch (provider) {
-        case GPS_PROVIDER:
-          isGpsEnabled = true;
-          break;
-        case NETWORK_PROVIDER:
-          isNetworkEnabled = true;
-          break;
-        default:
-          break;
-      }
-    }
-
-    public List<Location> getAllLocations() {
-      return locations;
-    }
-
-    public Location getMostRecentLocation() {
-      return locations.get(locations.size() - 1);
-    }
   }
 
   @Test public void requestLocationUpdates_shouldNotifyBothListeners() {
@@ -534,6 +524,52 @@ public class FusedLocationProviderServiceImplTest {
     assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
   }
 
+  @Test public void requestLocationUpdates_shouldReportResult() {
+    TestLocationCallback callback = new TestLocationCallback();
+    Looper looper = Looper.myLooper();
+    LocationRequest request = LocationRequest.create();
+    api.requestLocationUpdates(request, callback, looper);
+    Location location = getTestLocation(NETWORK_PROVIDER, 0, 0, 0);
+    shadowLocationManager.simulateLocation(location);
+    assertThat(callback.getResult().getLastLocation()).isEqualTo(location);
+  }
+
+  @Test public void requestLocationUpdates_shouldReportAvailability() {
+    TestLocationCallback callback = new TestLocationCallback();
+    Looper looper = Looper.myLooper();
+    LocationRequest request = LocationRequest.create();
+    api.requestLocationUpdates(request, callback, looper);
+    shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
+    assertThat(callback.getAvailability().isLocationAvailable()).isEqualTo(true);
+  }
+
+  @Test public void getLocationAvailability_gps_network_shouldBeAvailable() {
+    shadowLocationManager.setProviderEnabled(GPS_PROVIDER, true);
+    shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
+
+    LocationAvailability availability = api.getLocationAvailability();
+    assertThat(availability.isLocationAvailable()).isTrue();
+  }
+
+  @Test public void getLocationAvailability_gps_shouldBeAvailable() {
+    shadowLocationManager.setProviderEnabled(GPS_PROVIDER, true);
+
+    LocationAvailability availability = api.getLocationAvailability();
+    assertThat(availability.isLocationAvailable()).isTrue();
+  }
+
+  @Test public void getLocationAvailability_network_shouldBeAvailable() {
+    shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
+
+    LocationAvailability availability = api.getLocationAvailability();
+    assertThat(availability.isLocationAvailable()).isTrue();
+  }
+
+  @Test public void getLocationAvailability_shouldBeUnavailable() {
+    LocationAvailability availability = api.getLocationAvailability();
+    assertThat(availability.isLocationAvailable()).isFalse();
+  }
+
   @Test public void removeLocationUpdates_shouldNotKillEngineIfListenerStillActive()
       throws Exception {
     TestLocationListener listener = new TestLocationListener();
@@ -556,6 +592,15 @@ public class FusedLocationProviderServiceImplTest {
 
     api.removeLocationUpdates(listener);
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isNotEmpty();
+  }
+
+  @Test public void removeLocationUpdates_locationCallback_shouldUnregisterAllListeners() {
+    TestLocationCallback callback = new TestLocationCallback();
+    Looper looper = mock(Looper.class);
+    LocationRequest request = LocationRequest.create();
+    api.requestLocationUpdates(request, callback, looper);
+    api.removeLocationUpdates(callback);
+    assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isEmpty();
   }
 
   @Test public void shutdown_shouldUnregisterLocationUpdateListeners() throws Exception {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
@@ -535,6 +535,8 @@ public class FusedLocationProviderServiceImplTest {
   }
 
   @Test public void requestLocationUpdates_shouldReportAvailability() {
+    Location location = new Location("test");
+    shadowLocationManager.setLastKnownLocation(NETWORK_PROVIDER, location);
     TestLocationCallback callback = new TestLocationCallback();
     Looper looper = Looper.myLooper();
     LocationRequest request = LocationRequest.create();
@@ -546,23 +548,51 @@ public class FusedLocationProviderServiceImplTest {
   @Test public void getLocationAvailability_gps_network_shouldBeAvailable() {
     shadowLocationManager.setProviderEnabled(GPS_PROVIDER, true);
     shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
+    Location location = new Location("test");
+    shadowLocationManager.setLastKnownLocation(GPS_PROVIDER, location);
 
     LocationAvailability availability = api.getLocationAvailability();
     assertThat(availability.isLocationAvailable()).isTrue();
+  }
+
+  @Test public void getLocationAvailability_gps_network_shouldBeUnavailable() {
+    shadowLocationManager.setProviderEnabled(GPS_PROVIDER, true);
+    shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
+
+    LocationAvailability availability = api.getLocationAvailability();
+    assertThat(availability.isLocationAvailable()).isFalse();
   }
 
   @Test public void getLocationAvailability_gps_shouldBeAvailable() {
     shadowLocationManager.setProviderEnabled(GPS_PROVIDER, true);
+    Location location = new Location("test");
+    shadowLocationManager.setLastKnownLocation(GPS_PROVIDER, location);
 
     LocationAvailability availability = api.getLocationAvailability();
     assertThat(availability.isLocationAvailable()).isTrue();
   }
 
+  @Test public void getLocationAvailability_gps_shouldBeUnavailable() {
+    shadowLocationManager.setProviderEnabled(GPS_PROVIDER, true);
+
+    LocationAvailability availability = api.getLocationAvailability();
+    assertThat(availability.isLocationAvailable()).isFalse();
+  }
+
   @Test public void getLocationAvailability_network_shouldBeAvailable() {
     shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
+    Location location = new Location("test");
+    shadowLocationManager.setLastKnownLocation(NETWORK_PROVIDER, location);
 
     LocationAvailability availability = api.getLocationAvailability();
     assertThat(availability.isLocationAvailable()).isTrue();
+  }
+
+  @Test public void getLocationAvailability_network_shouldBeUnavailable() {
+    shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
+
+    LocationAvailability availability = api.getLocationAvailability();
+    assertThat(availability.isLocationAvailable()).isFalse();
   }
 
   @Test public void getLocationAvailability_shouldBeUnavailable() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestLocationCallback.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestLocationCallback.java
@@ -1,0 +1,27 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationCallback;
+import com.mapzen.android.lost.api.LocationResult;
+
+public class TestLocationCallback implements LocationCallback {
+
+  private LocationAvailability availability;
+  private LocationResult result;
+
+  @Override public void onLocationAvailability(LocationAvailability locationAvailability) {
+    availability = locationAvailability;
+  }
+
+  @Override public void onLocationResult(LocationResult locationResult) {
+    result = locationResult;
+  }
+
+  public LocationAvailability getAvailability() {
+    return availability;
+  }
+
+  public LocationResult getResult() {
+    return result;
+  }
+}

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestLocationListener.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestLocationListener.java
@@ -4,17 +4,68 @@ import com.mapzen.android.lost.api.LocationListener;
 
 import android.location.Location;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static android.location.LocationManager.GPS_PROVIDER;
+import static android.location.LocationManager.NETWORK_PROVIDER;
 
 public class TestLocationListener implements LocationListener {
-  @Override public void onLocationChanged(Location location) {
+  private ArrayList<Location> locations = new ArrayList<>();
+  private boolean isGpsEnabled = true;
+  private boolean isNetworkEnabled = true;
 
+  @Override public void onLocationChanged(Location location) {
+    locations.add(location);
   }
 
   @Override public void onProviderDisabled(String provider) {
-
+    switch (provider) {
+      case GPS_PROVIDER:
+        isGpsEnabled = false;
+        break;
+      case NETWORK_PROVIDER:
+        isNetworkEnabled = false;
+        break;
+      default:
+        break;
+    }
   }
 
   @Override public void onProviderEnabled(String provider) {
+    switch (provider) {
+      case GPS_PROVIDER:
+        isGpsEnabled = true;
+        break;
+      case NETWORK_PROVIDER:
+        isNetworkEnabled = true;
+        break;
+      default:
+        break;
+    }
+  }
 
+  public List<Location> getAllLocations() {
+    return locations;
+  }
+
+  public Location getMostRecentLocation() {
+    return locations.get(locations.size() - 1);
+  }
+
+  public void setIsGpsEnabled(boolean enabled) {
+    isGpsEnabled = enabled;
+  }
+
+  public boolean getIsGpsEnabled() {
+    return isGpsEnabled;
+  }
+
+  public void setIsNetworkEnabled(boolean enabled) {
+    isNetworkEnabled = enabled;
+  }
+
+  public boolean getIsNetworkEnabled() {
+    return isNetworkEnabled;
   }
 }


### PR DESCRIPTION
### Overview
This PR adds the ability to query for `LocationAvailability` as well as the ability to request location updates for a given `LocationCallback`. It also makes `PendingIntent`s more complete with information and adds extras `EXTRA_LOCATION_AVAILABILITY` and `EXTRA_LOCATION_RESULT` to be delivered with each `Intent`.

### Proposed Changes
The `FusedLocationProviderApi` api has three new methods (`getLocationAvailability()`, `requestLocationUpdates(LocationRequest request, LocationCallback callback, Looper looper)`, and `removeLocationUpdates(LocationCallback callback)`). This PR also adds a new `Parcelable` class `LocationAvailability` as well as a new interface, `LocationCallback`.

Closes #64 
