### PR TITLE
PendingResult return type

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -25,32 +25,32 @@ public interface FusedLocationProviderApi {
   LocationAvailability getLocationAvailability(LostApiClient client);
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  void requestLocationUpdates(LostApiClient client, LocationRequest request,
+  PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       LocationListener listener);
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  void requestLocationUpdates(LostApiClient client, LocationRequest request,
+  PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       LocationListener listener, Looper looper);
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  void requestLocationUpdates(LostApiClient client, LocationRequest request,
+  PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       LocationCallback callback, Looper looper);
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  void requestLocationUpdates(LostApiClient client, LocationRequest request,
+  PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       PendingIntent callbackIntent);
 
-  void removeLocationUpdates(LostApiClient client, LocationListener listener);
+  PendingResult<Status> removeLocationUpdates(LostApiClient client, LocationListener listener);
 
-  void removeLocationUpdates(LostApiClient client, PendingIntent callbackIntent);
+  PendingResult<Status> removeLocationUpdates(LostApiClient client, PendingIntent callbackIntent);
 
-  void removeLocationUpdates(LostApiClient client, LocationCallback callback);
+  PendingResult<Status> removeLocationUpdates(LostApiClient client, LocationCallback callback);
 
-  void setMockMode(LostApiClient client, boolean isMockMode);
+  PendingResult<Status> setMockMode(LostApiClient client, boolean isMockMode);
 
-  void setMockLocation(LostApiClient client, Location mockLocation);
+  PendingResult<Status> setMockLocation(LostApiClient client, Location mockLocation);
 
-  void setMockTrace(LostApiClient client, final File file);
+  PendingResult<Status> setMockTrace(LostApiClient client, final File file);
 
   /**
    * @deprecated Use {@link SettingsApi#checkLocationSettings(LostApiClient,

--- a/lost/src/main/java/com/mapzen/android/lost/api/Status.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/Status.java
@@ -4,7 +4,7 @@ import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.IntentSender;
 
-public class Status {
+public class Status implements Result {
 
   public static final int SUCCESS = 0;
   public static final int RESOLUTION_REQUIRED = 6;
@@ -89,5 +89,9 @@ public class Status {
 
   public PendingIntent getResolution() {
     return this.mPendingIntent;
+  }
+
+  @Override public Status getStatus() {
+    return this;
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
@@ -30,9 +30,9 @@ public interface ClientManager {
       PendingIntent callbackIntent);
   void addLocationCallback(LostApiClient client, LocationRequest request,
       LocationCallback callback, Looper looper);
-  void removeListener(LostApiClient client, LocationListener listener);
-  void removePendingIntent(LostApiClient client, PendingIntent callbackIntent);
-  void removeLocationCallback(LostApiClient client, LocationCallback callback);
+  boolean removeListener(LostApiClient client, LocationListener listener);
+  boolean removePendingIntent(LostApiClient client, PendingIntent callbackIntent);
+  boolean removeLocationCallback(LostApiClient client, LocationCallback callback);
   void reportLocationChanged(Location location);
   void sendPendingIntent(Context context, Location location, LocationAvailability availability,
       LocationResult result);

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationPendingResult.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationPendingResult.java
@@ -3,6 +3,7 @@ package com.mapzen.android.lost.internal;
 import com.mapzen.android.lost.api.PendingResult;
 import com.mapzen.android.lost.api.Result;
 import com.mapzen.android.lost.api.ResultCallback;
+import com.mapzen.android.lost.api.Status;
 
 import android.support.annotation.NonNull;
 
@@ -10,12 +11,18 @@ import java.util.concurrent.TimeUnit;
 
 public class FusedLocationPendingResult extends PendingResult {
 
+  private boolean hasResult = false;
+
+  public FusedLocationPendingResult(boolean hasResult) {
+    this.hasResult = hasResult;
+  }
+
   @NonNull @Override public Result await() {
-    return null;
+    return generateResult();
   }
 
   @NonNull @Override public Result await(long time, @NonNull TimeUnit timeUnit) {
-    return null;
+    return generateResult();
   }
 
   @Override public void cancel() {
@@ -27,11 +34,23 @@ public class FusedLocationPendingResult extends PendingResult {
   }
 
   @Override public void setResultCallback(@NonNull ResultCallback callback) {
-
+    if (hasResult) {
+      callback.onResult(generateResult());
+    }
   }
 
   @Override public void setResultCallback(@NonNull ResultCallback callback, long time,
       @NonNull TimeUnit timeUnit) {
+    if (hasResult) {
+      callback.onResult(generateResult());
+    }
+  }
 
+  private Result generateResult() {
+    return new Result() {
+      @Override public Status getStatus() {
+        return new Status(Status.SUCCESS);
+      }
+    };
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationPendingResult.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationPendingResult.java
@@ -1,0 +1,37 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.PendingResult;
+import com.mapzen.android.lost.api.Result;
+import com.mapzen.android.lost.api.ResultCallback;
+
+import android.support.annotation.NonNull;
+
+import java.util.concurrent.TimeUnit;
+
+public class FusedLocationPendingResult extends PendingResult {
+
+  @NonNull @Override public Result await() {
+    return null;
+  }
+
+  @NonNull @Override public Result await(long time, @NonNull TimeUnit timeUnit) {
+    return null;
+  }
+
+  @Override public void cancel() {
+
+  }
+
+  @Override public boolean isCanceled() {
+    return false;
+  }
+
+  @Override public void setResultCallback(@NonNull ResultCallback callback) {
+
+  }
+
+  @Override public void setResultCallback(@NonNull ResultCallback callback, long time,
+      @NonNull TimeUnit timeUnit) {
+
+  }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationPendingResult.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationPendingResult.java
@@ -9,7 +9,7 @@ import android.support.annotation.NonNull;
 
 import java.util.concurrent.TimeUnit;
 
-public class FusedLocationPendingResult extends PendingResult {
+public class FusedLocationPendingResult extends PendingResult<Status> {
 
   private boolean hasResult = false;
 
@@ -17,12 +17,12 @@ public class FusedLocationPendingResult extends PendingResult {
     this.hasResult = hasResult;
   }
 
-  @NonNull @Override public Result await() {
-    return generateResult();
+  @NonNull @Override public Status await() {
+    return generateStatus();
   }
 
-  @NonNull @Override public Result await(long time, @NonNull TimeUnit timeUnit) {
-    return generateResult();
+  @NonNull @Override public Status await(long time, @NonNull TimeUnit timeUnit) {
+    return generateStatus();
   }
 
   @Override public void cancel() {
@@ -46,10 +46,14 @@ public class FusedLocationPendingResult extends PendingResult {
     }
   }
 
+  private Status generateStatus() {
+    return new Status(Status.SUCCESS);
+  }
+
   private Result generateResult() {
     return new Result() {
       @Override public Status getStatus() {
-        return new Status(Status.SUCCESS);
+        return generateStatus();
       }
     };
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -6,6 +6,8 @@ import com.mapzen.android.lost.api.LocationCallback;
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LostApiClient;
+import com.mapzen.android.lost.api.PendingResult;
+import com.mapzen.android.lost.api.Status;
 
 import android.app.PendingIntent;
 import android.content.ComponentName;
@@ -107,50 +109,53 @@ public class FusedLocationProviderApiImpl
     return service.getLocationAvailability(client);
   }
 
-  @Override public void requestLocationUpdates(LostApiClient client, LocationRequest request,
-      LocationListener listener) {
-    service.requestLocationUpdates(client, request, listener);
+  @Override public PendingResult<Status> requestLocationUpdates(LostApiClient client,
+      LocationRequest request, LocationListener listener) {
+    return service.requestLocationUpdates(client, request, listener);
   }
 
-  @Override public void requestLocationUpdates(LostApiClient client, LocationRequest request,
-      LocationListener listener, Looper looper) {
+  @Override public PendingResult<Status> requestLocationUpdates(LostApiClient client,
+      LocationRequest request, LocationListener listener, Looper looper) {
     throw new RuntimeException("Sorry, not yet implemented");
   }
 
-  @Override public void requestLocationUpdates(LostApiClient client, LocationRequest request,
-      LocationCallback callback, Looper looper) {
-    service.requestLocationUpdates(client, request, callback, looper);
+  @Override public PendingResult<Status> requestLocationUpdates(LostApiClient client,
+      LocationRequest request, LocationCallback callback, Looper looper) {
+    return service.requestLocationUpdates(client, request, callback, looper);
   }
 
   @Override
-  public void requestLocationUpdates(LostApiClient client, LocationRequest request,
+  public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       PendingIntent callbackIntent) {
-    service.requestLocationUpdates(client, request, callbackIntent);
+    return service.requestLocationUpdates(client, request, callbackIntent);
   }
 
-  @Override public void removeLocationUpdates(LostApiClient client, LocationListener listener) {
-    service.removeLocationUpdates(client, listener);
+  @Override public PendingResult<Status> removeLocationUpdates(LostApiClient client,
+      LocationListener listener) {
+    return service.removeLocationUpdates(client, listener);
   }
 
-  @Override public void removeLocationUpdates(LostApiClient client,
+  @Override public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       PendingIntent callbackIntent) {
-    service.removeLocationUpdates(client, callbackIntent);
+    return service.removeLocationUpdates(client, callbackIntent);
   }
 
-  @Override public void removeLocationUpdates(LostApiClient client, LocationCallback callback) {
-    service.removeLocationUpdates(client, callback);
+  @Override public PendingResult<Status> removeLocationUpdates(LostApiClient client,
+      LocationCallback callback) {
+    return service.removeLocationUpdates(client, callback);
   }
 
-  @Override public void setMockMode(LostApiClient client, boolean isMockMode) {
-    service.setMockMode(client, isMockMode);
+  @Override public PendingResult<Status> setMockMode(LostApiClient client, boolean isMockMode) {
+    return service.setMockMode(client, isMockMode);
   }
 
-  @Override public void setMockLocation(LostApiClient client, Location mockLocation) {
-    service.setMockLocation(client, mockLocation);
+  @Override public PendingResult<Status> setMockLocation(LostApiClient client,
+      Location mockLocation) {
+    return service.setMockLocation(client, mockLocation);
   }
 
-  @Override public void setMockTrace(LostApiClient client, File file) {
-    service.setMockTrace(client, file);
+  @Override public PendingResult<Status> setMockTrace(LostApiClient client, File file) {
+    return service.setMockTrace(client, file);
   }
 
   @Override public boolean isProviderEnabled(LostApiClient client, String provider) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
@@ -5,6 +5,8 @@ import com.mapzen.android.lost.api.LocationCallback;
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LostApiClient;
+import com.mapzen.android.lost.api.PendingResult;
+import com.mapzen.android.lost.api.Status;
 
 import android.app.PendingIntent;
 import android.app.Service;
@@ -62,43 +64,46 @@ public class FusedLocationProviderService extends Service {
     return serviceImpl.getLocationAvailability(client);
   }
 
-  public void requestLocationUpdates(LostApiClient client, LocationRequest request,
+  public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       LocationListener listener) {
-    serviceImpl.requestLocationUpdates(client, request, listener);
+    return serviceImpl.requestLocationUpdates(client, request, listener);
   }
 
-  public void requestLocationUpdates(LostApiClient client, LocationRequest request,
+  public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       PendingIntent callbackIntent) {
-    serviceImpl.requestLocationUpdates(client, request, callbackIntent);
+    return serviceImpl.requestLocationUpdates(client, request, callbackIntent);
   }
 
-  public void requestLocationUpdates(LostApiClient client, LocationRequest request,
+  public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       LocationCallback callback, Looper looper) {
-    serviceImpl.requestLocationUpdates(client, request, callback, looper);
+    return serviceImpl.requestLocationUpdates(client, request, callback, looper);
   }
 
-  public void removeLocationUpdates(LostApiClient client, LocationListener listener) {
-    serviceImpl.removeLocationUpdates(client, listener);
+  public PendingResult<Status> removeLocationUpdates(LostApiClient client,
+      LocationListener listener) {
+    return serviceImpl.removeLocationUpdates(client, listener);
   }
 
-  public void removeLocationUpdates(LostApiClient client, PendingIntent callbackIntent) {
-    serviceImpl.removeLocationUpdates(client, callbackIntent);
+  public PendingResult<Status> removeLocationUpdates(LostApiClient client,
+      PendingIntent callbackIntent) {
+    return serviceImpl.removeLocationUpdates(client, callbackIntent);
   }
 
-  public void removeLocationUpdates(LostApiClient client, LocationCallback callback) {
-    serviceImpl.removeLocationUpdates(client, callback);
+  public PendingResult<Status> removeLocationUpdates(LostApiClient client,
+      LocationCallback callback) {
+    return serviceImpl.removeLocationUpdates(client, callback);
   }
 
-  public void setMockMode(LostApiClient client, boolean isMockMode) {
-    serviceImpl.setMockMode(client, isMockMode);
+  public PendingResult<Status> setMockMode(LostApiClient client, boolean isMockMode) {
+    return serviceImpl.setMockMode(client, isMockMode);
   }
 
-  public void setMockLocation(LostApiClient client, Location mockLocation) {
-    serviceImpl.setMockLocation(client, mockLocation);
+  public PendingResult<Status> setMockLocation(LostApiClient client, Location mockLocation) {
+    return serviceImpl.setMockLocation(client, mockLocation);
   }
 
-  public void setMockTrace(LostApiClient client, File file) {
-    serviceImpl.setMockTrace(client, file);
+  public PendingResult<Status> setMockTrace(LostApiClient client, File file) {
+    return serviceImpl.setMockTrace(client, file);
   }
 
   public boolean isProviderEnabled(LostApiClient client, String provider) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
@@ -56,63 +56,63 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
       LocationListener listener) {
     clientManager.addListener(client, request, listener);
     locationEngine.setRequest(request);
-    return new FusedLocationPendingResult();
+    return new FusedLocationPendingResult(true);
   }
 
   public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       PendingIntent callbackIntent) {
     clientManager.addPendingIntent(client, request, callbackIntent);
     locationEngine.setRequest(request);
-    return new FusedLocationPendingResult();
+    return new FusedLocationPendingResult(true);
   }
 
   public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       LocationCallback callback, Looper looper) {
     clientManager.addLocationCallback(client, request, callback, looper);
     locationEngine.setRequest(request);
-    return new FusedLocationPendingResult();
+    return new FusedLocationPendingResult(true);
   }
 
   public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       LocationListener listener) {
-    clientManager.removeListener(client, listener);
+    boolean hasResult = clientManager.removeListener(client, listener);
     checkAllListenersPendingIntentsAndCallbacks();
-    return new FusedLocationPendingResult();
+    return new FusedLocationPendingResult(hasResult);
   }
 
   public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       PendingIntent callbackIntent) {
-    clientManager.removePendingIntent(client, callbackIntent);
+    boolean hasResult = clientManager.removePendingIntent(client, callbackIntent);
     checkAllListenersPendingIntentsAndCallbacks();
-    return new FusedLocationPendingResult();
+    return new FusedLocationPendingResult(hasResult);
   }
 
   public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       LocationCallback callback) {
-    clientManager.removeLocationCallback(client, callback);
+    boolean hasResult = clientManager.removeLocationCallback(client, callback);
     checkAllListenersPendingIntentsAndCallbacks();
-    return new FusedLocationPendingResult();
+    return new FusedLocationPendingResult(hasResult);
   }
 
   public PendingResult<Status> setMockMode(LostApiClient client, boolean isMockMode) {
     if (mockMode != isMockMode) {
       toggleMockMode();
     }
-    return new FusedLocationPendingResult();
+    return new FusedLocationPendingResult(true);
   }
 
   public PendingResult<Status> setMockLocation(LostApiClient client, Location mockLocation) {
     if (mockMode) {
       ((MockEngine) locationEngine).setLocation(mockLocation);
     }
-    return new FusedLocationPendingResult();
+    return new FusedLocationPendingResult(true);
   }
 
   public PendingResult<Status> setMockTrace(LostApiClient client, File file) {
     if (mockMode) {
       ((MockEngine) locationEngine).setTrace(file);
     }
-    return new FusedLocationPendingResult();
+    return new FusedLocationPendingResult(true);
   }
 
   public boolean isProviderEnabled(LostApiClient client, String provider) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
@@ -6,6 +6,8 @@ import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LocationResult;
 import com.mapzen.android.lost.api.LostApiClient;
+import com.mapzen.android.lost.api.PendingResult;
+import com.mapzen.android.lost.api.Status;
 
 import android.app.PendingIntent;
 import android.content.Context;
@@ -50,55 +52,67 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
     return locationEngine.createLocationAvailability();
   }
 
-  public void requestLocationUpdates(LostApiClient client, LocationRequest request,
+  public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       LocationListener listener) {
     clientManager.addListener(client, request, listener);
     locationEngine.setRequest(request);
+    return new FusedLocationPendingResult();
   }
 
-  public void requestLocationUpdates(LostApiClient client, LocationRequest request,
+  public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       PendingIntent callbackIntent) {
     clientManager.addPendingIntent(client, request, callbackIntent);
     locationEngine.setRequest(request);
+    return new FusedLocationPendingResult();
   }
 
-  public void requestLocationUpdates(LostApiClient client, LocationRequest request,
+  public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       LocationCallback callback, Looper looper) {
     clientManager.addLocationCallback(client, request, callback, looper);
     locationEngine.setRequest(request);
+    return new FusedLocationPendingResult();
   }
 
-  public void removeLocationUpdates(LostApiClient client, LocationListener listener) {
+  public PendingResult<Status> removeLocationUpdates(LostApiClient client,
+      LocationListener listener) {
     clientManager.removeListener(client, listener);
     checkAllListenersPendingIntentsAndCallbacks();
+    return new FusedLocationPendingResult();
   }
 
-  public void removeLocationUpdates(LostApiClient client, PendingIntent callbackIntent) {
+  public PendingResult<Status> removeLocationUpdates(LostApiClient client,
+      PendingIntent callbackIntent) {
     clientManager.removePendingIntent(client, callbackIntent);
     checkAllListenersPendingIntentsAndCallbacks();
+    return new FusedLocationPendingResult();
   }
 
-  public void removeLocationUpdates(LostApiClient client, LocationCallback callback) {
+  public PendingResult<Status> removeLocationUpdates(LostApiClient client,
+      LocationCallback callback) {
     clientManager.removeLocationCallback(client, callback);
     checkAllListenersPendingIntentsAndCallbacks();
+    return new FusedLocationPendingResult();
   }
 
-  public void setMockMode(LostApiClient client, boolean isMockMode) {
+  public PendingResult<Status> setMockMode(LostApiClient client, boolean isMockMode) {
     if (mockMode != isMockMode) {
       toggleMockMode();
     }
+    return new FusedLocationPendingResult();
   }
 
-  public void setMockLocation(LostApiClient client, Location mockLocation) {
+  public PendingResult<Status> setMockLocation(LostApiClient client, Location mockLocation) {
     if (mockMode) {
       ((MockEngine) locationEngine).setLocation(mockLocation);
     }
+    return new FusedLocationPendingResult();
   }
 
-  public void setMockTrace(LostApiClient client, File file) {
+  public PendingResult<Status> setMockTrace(LostApiClient client, File file) {
     if (mockMode) {
       ((MockEngine) locationEngine).setTrace(file);
     }
+    return new FusedLocationPendingResult();
   }
 
   public boolean isProviderEnabled(LostApiClient client, String provider) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
@@ -112,10 +112,11 @@ public class LostClientManager implements ClientManager {
     Set<LocationListener> listeners = clientToListeners.get(client);
     if (listeners != null) {
       listeners.remove(listener);
+      if (listeners.isEmpty()) {
+        clientToListeners.remove(client);
+      }
     }
-    if (listeners.isEmpty()) {
-      clientToListeners.remove(client);
-    }
+
     return removedListener;
   }
 
@@ -127,9 +128,9 @@ public class LostClientManager implements ClientManager {
     Set<PendingIntent> intents = clientToPendingIntents.get(client);
     if (intents != null) {
       intents.remove(callbackIntent);
-    }
-    if (intents.isEmpty()) {
-      clientToPendingIntents.remove(client);
+      if (intents.isEmpty()) {
+        clientToPendingIntents.remove(client);
+      }
     }
     return removedPendingIntent;
   }
@@ -142,16 +143,17 @@ public class LostClientManager implements ClientManager {
     Set<LocationCallback> callbacks = clientToLocationCallbacks.get(client);
     if (callbacks != null) {
       callbacks.remove(callback);
+      if (callbacks.isEmpty()) {
+        clientToLocationCallbacks.remove(client);
+      }
     }
-    if (callbacks.isEmpty()) {
-      clientToLocationCallbacks.remove(client);
-    }
+
     Map<LocationCallback, Looper> looperMap = clientCallbackToLoopers.get(client);
     if (looperMap != null) {
       looperMap.remove(callback);
-    }
-    if (looperMap.isEmpty()) {
-      clientCallbackToLoopers.remove(client);
+      if (looperMap.isEmpty()) {
+        clientCallbackToLoopers.remove(client);
+      }
     }
     return removedCallback;
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
@@ -104,7 +104,11 @@ public class LostClientManager implements ClientManager {
     clientCallbackToLoopers.put(client, looperMap);
   }
 
-  public void removeListener(LostApiClient client, LocationListener listener) {
+  public boolean removeListener(LostApiClient client, LocationListener listener) {
+    boolean removedListener = false;
+    if (clientToListeners.get(client) != null) {
+      removedListener = clientToListeners.get(client).contains(listener);
+    }
     Set<LocationListener> listeners = clientToListeners.get(client);
     if (listeners != null) {
       listeners.remove(listener);
@@ -112,9 +116,14 @@ public class LostClientManager implements ClientManager {
     if (listeners.isEmpty()) {
       clientToListeners.remove(client);
     }
+    return removedListener;
   }
 
-  public void removePendingIntent(LostApiClient client, PendingIntent callbackIntent) {
+  public boolean removePendingIntent(LostApiClient client, PendingIntent callbackIntent) {
+    boolean removedPendingIntent = false;
+    if (clientToPendingIntents.get(client) != null) {
+      removedPendingIntent = clientToPendingIntents.get(client).contains(callbackIntent);
+    }
     Set<PendingIntent> intents = clientToPendingIntents.get(client);
     if (intents != null) {
       intents.remove(callbackIntent);
@@ -122,9 +131,14 @@ public class LostClientManager implements ClientManager {
     if (intents.isEmpty()) {
       clientToPendingIntents.remove(client);
     }
+    return removedPendingIntent;
   }
 
-  public void removeLocationCallback(LostApiClient client, LocationCallback callback) {
+  public boolean removeLocationCallback(LostApiClient client, LocationCallback callback) {
+    boolean removedCallback = false;
+    if (clientToLocationCallbacks.get(client) != null) {
+      removedCallback = clientToLocationCallbacks.get(client).contains(callback);
+    }
     Set<LocationCallback> callbacks = clientToLocationCallbacks.get(client);
     if (callbacks != null) {
       callbacks.remove(callback);
@@ -139,6 +153,7 @@ public class LostClientManager implements ClientManager {
     if (looperMap.isEmpty()) {
       clientCallbackToLoopers.remove(client);
     }
+    return removedCallback;
   }
 
   public void reportLocationChanged(Location location) {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationPendingResultTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationPendingResultTest.java
@@ -1,0 +1,39 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.Status;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class FusedLocationPendingResultTest {
+
+  FusedLocationPendingResult result = new FusedLocationPendingResult(true);
+
+  @Test public void await_shouldReturnSuccess() {
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void await_delay_shouldReturnSuccess() {
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+  }
+
+  @Test public void isCancelled_shouldReturnFalse() {
+    assertThat(result.isCanceled()).isFalse();
+  }
+
+  @Test public void setResultCallback_shouldReturnSuccess() {
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void setResultCallback_delay_shouldReturnSuccess() {
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+}

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
@@ -1,10 +1,13 @@
 package com.mapzen.android.lost.internal;
 
 import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationCallback;
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LocationResult;
 import com.mapzen.android.lost.api.LostApiClient;
+import com.mapzen.android.lost.api.PendingResult;
+import com.mapzen.android.lost.api.Status;
 import com.mapzen.lost.BuildConfig;
 
 import com.google.common.base.Charsets;
@@ -38,6 +41,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static android.content.Context.LOCATION_SERVICE;
 import static android.location.LocationManager.GPS_PROVIDER;
@@ -841,6 +845,190 @@ public class FusedLocationProviderServiceImplTest {
     api.disconnect(client);
 
     assertThat(api.getLocationCallbacks().get(otherClient)).isNotNull();
+  }
+
+  @Test public void requestLocationUpdates_listener_shouldReturnFusedLocationPendingResult() {
+    TestLocationListener listener = new TestLocationListener();
+    PendingResult<Status> result = api.requestLocationUpdates(client, LocationRequest.create(),
+        listener);
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void requestLocationUpdates_pendingIntent_shouldReturnFusedLocationPendingResult() {
+    PendingIntent pendingIntent = mock(PendingIntent.class);
+    PendingResult<Status> result = api.requestLocationUpdates(client, LocationRequest.create(),
+        pendingIntent);
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void requestLocationUpdates_callback_shouldReturnFusedLocationPendingResult() {
+    LocationCallback locationCallback = new TestLocationCallback();
+    PendingResult<Status> result = api.requestLocationUpdates(client, LocationRequest.create(),
+        locationCallback, Looper.myLooper());
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void removeLocationUpdates_listener_shouldReturnFusedLocationPendingResult() {
+    TestLocationListener listener = new TestLocationListener();
+    api.requestLocationUpdates(client, LocationRequest.create(), listener);
+    PendingResult<Status> result = api.removeLocationUpdates(client, listener);
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void removeLocationUpdates_pendingIntent_shouldReturnFusedLocationPendingResult() {
+    PendingIntent pendingIntent = mock(PendingIntent.class);
+    api.requestLocationUpdates(client, LocationRequest.create(), pendingIntent);
+    PendingResult<Status> result = api.removeLocationUpdates(client, pendingIntent);
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void removeLocationUpdates_callback_shouldReturnFusedLocationPendingResult() {
+    LocationCallback locationCallback = new TestLocationCallback();
+    api.requestLocationUpdates(client, LocationRequest.create(), locationCallback,
+        Looper.myLooper());
+    PendingResult<Status> result = api.removeLocationUpdates(client, locationCallback);
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void removeNoLocationUpdates_listener_shouldReturnFusedLocationPendingResult() {
+    TestLocationListener listener = new TestLocationListener();
+    PendingResult<Status> result = api.removeLocationUpdates(client, listener);
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus()).isNull();
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus()).isNull();
+  }
+
+  @Test public void removeNoLocationUpdates_pendingIntent_shouldReturnFusedLocationPendingResult() {
+    PendingIntent pendingIntent = mock(PendingIntent.class);
+    PendingResult<Status> result = api.removeLocationUpdates(client, pendingIntent);
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus()).isNull();
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus()).isNull();
+  }
+
+  @Test public void removeNoLocationUpdates_callback_shouldReturnFusedLocationPendingResult() {
+    LocationCallback locationCallback = new TestLocationCallback();
+    PendingResult<Status> result = api.removeLocationUpdates(client, locationCallback);
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus()).isNull();
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus()).isNull();
+  }
+
+  @Test public void setMockMode_shouldReturnFusedLocationPendingResult() {
+    PendingResult<Status> result = api.setMockMode(client, true);
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void setMockLocation_shouldReturnFusedLocationPendingResult() {
+    PendingResult<Status> result = api.setMockLocation(client, new Location("test"));
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void setMockTrace_shouldReturnFusedLocationPendingResult() {
+    PendingResult<Status> result = api.setMockTrace(client, new File("test"));
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    TestResultCallback callback = new TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    TestResultCallback otherCallback = new TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
   }
 
   /**

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestResultCallback.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestResultCallback.java
@@ -1,0 +1,20 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.Result;
+import com.mapzen.android.lost.api.ResultCallback;
+import com.mapzen.android.lost.api.Status;
+
+import android.support.annotation.NonNull;
+
+public class TestResultCallback implements ResultCallback<Result> {
+
+  private Status status;
+
+  @Override public void onResult(@NonNull Result result) {
+    status = result.getStatus();
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+}


### PR DESCRIPTION
### Overview
This PR updates the return type in several `FusedLocationProviderApi` methods from `void` to `PendingResult`

### Proposed Changes
A `FusedLocationPendingResult` object will be returned for the updated `FusedLocationProviderApi` methods. This is a simple object that always returns a `Status` with code `Status#SUCCESS`. In cases where `FusedLocationProviderApi#removeLocationUpdates` is called without `FusedLocationProviderApi#registerLocationUpdates`, the returned result object will do nothing when `FusedLocationPendingResult#setResultCallback` is invoked.

Scenarios I tested on play services which inspired the design of this include:
-request location when location services disabled -> `Result.Success`
-request location before client connected -> `IllegialStateException` thrown
-request location updates without setting priority, fastest interval, interval -> `Result.Success`
-remove location updates without requesting them for a listener - get no result when setResultCallback called
-calling cancel on `PendingIntent` -> does not remove listener, returns `Result.Success`

Closes #82 