### PR TITLE
Make LocationServices fields final

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -8,6 +8,6 @@
     <suppress checks="MemberName" files=".*src/test/java/*" />
     <suppress checks="MagicNumberCheck" files=".*src/test/java/*" />
 
-    <suppress checks="StaticVariableName" files="src/main/java/com/mapzen/android/lost/api/LocationServices.java" />
+    <suppress checks="ConstantName" files="src/main/java/com/mapzen/android/lost/api/LocationServices.java"/>
     <suppress checks="VisibilityModifier" files="src/main/java/com/mapzen/android/lost/api/LocationServices.java" />
 </suppressions>

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationServices.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationServices.java
@@ -1,10 +1,15 @@
 package com.mapzen.android.lost.api;
 
+import com.mapzen.android.lost.internal.FusedLocationProviderApiImpl;
+import com.mapzen.android.lost.internal.GeofencingApiImpl;
+import com.mapzen.android.lost.internal.SettingsApiImpl;
+
 public class LocationServices {
 
-  public static FusedLocationProviderApi FusedLocationApi;
+  public static final FusedLocationProviderApi FusedLocationApi =
+      new FusedLocationProviderApiImpl();
 
-  public static GeofencingApi GeofencingApi;
+  public static final GeofencingApi GeofencingApi = new GeofencingApiImpl();
 
-  public static SettingsApi SettingsApi;
+  public static final SettingsApi SettingsApi = new SettingsApiImpl();
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -32,7 +32,7 @@ public class FusedLocationProviderApiImpl
 
   private static final String TAG = FusedLocationProviderApiImpl.class.getSimpleName();
 
-  private final Context context;
+  private Context context;
   private FusedLocationProviderService service;
   private boolean connecting;
 
@@ -66,17 +66,17 @@ public class FusedLocationProviderApiImpl
 
   Set<LostApiClient.ConnectionCallbacks> connectionCallbacks;
 
-  public FusedLocationProviderApiImpl(Context context) {
-    this.context = context;
-    connectionCallbacks = new HashSet<>();
-  }
 
   public boolean isConnecting() {
     return connecting;
   }
 
-  public void connect(LostApiClient.ConnectionCallbacks callbacks) {
-    connecting = true;
+  public FusedLocationProviderApiImpl() {
+    connectionCallbacks = new HashSet<>();
+  }
+
+  public void connect(Context context, LostApiClient.ConnectionCallbacks callbacks) {
+    this.context = context;
 
     Intent intent = new Intent(context, FusedLocationProviderService.class);
     context.startService(intent);
@@ -86,6 +86,10 @@ public class FusedLocationProviderApiImpl
     }
     intent = new Intent(context, FusedLocationProviderService.class);
     context.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE);
+  }
+
+  public void disconnect() {
+    disconnect(null, true);
   }
 
   public void disconnect(LostApiClient client, boolean stopService) {
@@ -98,7 +102,13 @@ public class FusedLocationProviderApiImpl
 
       Intent intent = new Intent(context, FusedLocationProviderService.class);
       context.stopService(intent);
+
+      service = null;
     }
+  }
+
+  public boolean isConnected() {
+    return service != null;
   }
 
   @Override public Location getLastLocation(LostApiClient client) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
@@ -21,15 +21,25 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
  */
 public class GeofencingApiImpl implements GeofencingApi {
 
-  private final LocationManager locationManager;
+  private LocationManager locationManager;
   private final HashMap<String, PendingIntent> pendingIntentMap;
 
-  GeofencingApiImpl(Context context) {
-    locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+  public GeofencingApiImpl() {
     pendingIntentMap = new HashMap<>();
   }
 
-  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
+  public void connect(Context context) {
+    locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+  }
+
+  public boolean isConnected() {
+    return locationManager != null;
+  }
+
+  public void disconnect() {
+    locationManager = null;
+  }
+
   @Override
   public void addGeofences(LostApiClient client, GeofencingRequest geofencingRequest,
       PendingIntent pendingIntent)

--- a/lost/src/main/java/com/mapzen/android/lost/internal/SettingsApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/SettingsApiImpl.java
@@ -16,9 +16,20 @@ public class SettingsApiImpl implements SettingsApi {
   private Context context;
   private BluetoothAdapter bluetoothAdapter;
 
-  public SettingsApiImpl(Context context) {
-    this.context = context;
+  public SettingsApiImpl() {
     bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+  }
+
+  public void connect(Context context) {
+    this.context = context;
+  }
+
+  public boolean isConnected() {
+    return context != null;
+  }
+
+  public void disconnect() {
+    context = null;
   }
 
   public SettingsApiImpl(Context context, BluetoothAdapter adapter) {

--- a/lost/src/test/java/com/mapzen/android/lost/api/LocationServicesTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/api/LocationServicesTest.java
@@ -5,12 +5,9 @@ import com.mapzen.android.lost.internal.GeofencingApiImpl;
 import com.mapzen.android.lost.internal.SettingsApiImpl;
 import com.mapzen.lost.BuildConfig;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static org.fest.assertions.api.Assertions.assertThat;

--- a/lost/src/test/java/com/mapzen/android/lost/api/LocationServicesTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/api/LocationServicesTest.java
@@ -16,15 +16,15 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
 public class LocationServicesTest {
 
-  @Test public void shouldCreateFusedLocationProviderApiImpl() {
+  @Test public void shouldCreateFusedLocationProviderApiImpl() throws Exception {
     assertThat(LocationServices.FusedLocationApi).isInstanceOf(FusedLocationProviderApiImpl.class);
   }
 
-  @Test public void shouldCreateGeofencingApiImpl() {
+  @Test public void shouldCreateGeofencingApiImpl() throws Exception {
     assertThat(LocationServices.GeofencingApi).isInstanceOf(GeofencingApiImpl.class);
   }
 
-  @Test public void shouldCreateSettingApiImpl() {
+  @Test public void shouldCreateSettingApiImpl() throws Exception {
     assertThat(LocationServices.SettingsApi).isInstanceOf(SettingsApiImpl.class);
   }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/api/LocationServicesTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/api/LocationServicesTest.java
@@ -2,6 +2,7 @@ package com.mapzen.android.lost.api;
 
 import com.mapzen.android.lost.internal.FusedLocationProviderApiImpl;
 import com.mapzen.android.lost.internal.GeofencingApiImpl;
+import com.mapzen.android.lost.internal.SettingsApiImpl;
 import com.mapzen.lost.BuildConfig;
 
 import org.junit.After;
@@ -17,22 +18,16 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
 public class LocationServicesTest {
-  private LostApiClient client;
 
-  @Before public void setUp() throws Exception {
-    client = new LostApiClient.Builder(RuntimeEnvironment.application).build();
-    client.connect();
-  }
-
-  @After public void tearDown() throws Exception {
-    client.disconnect();
-  }
-
-  @Test public void shouldCreateFusedLocationProviderApiImpl() throws Exception {
+  @Test public void shouldCreateFusedLocationProviderApiImpl() {
     assertThat(LocationServices.FusedLocationApi).isInstanceOf(FusedLocationProviderApiImpl.class);
   }
 
-  @Test public void shouldCreateGeofencingApiImpl() throws Exception {
+  @Test public void shouldCreateGeofencingApiImpl() {
     assertThat(LocationServices.GeofencingApi).isInstanceOf(GeofencingApiImpl.class);
+  }
+
+  @Test public void shouldCreateSettingApiImpl() {
+    assertThat(LocationServices.SettingsApi).isInstanceOf(SettingsApiImpl.class);
   }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -36,6 +36,7 @@ public class FusedLocationProviderApiImplTest {
 
   @Before public void setUp() throws Exception {
     mockService();
+    client = new LostApiClient.Builder(mock(Context.class)).build();
     api = new FusedLocationProviderApiImpl();
     api.connect(application, null);
     service = api.getService();

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -36,9 +36,8 @@ public class FusedLocationProviderApiImplTest {
 
   @Before public void setUp() throws Exception {
     mockService();
-    client = new LostApiClient.Builder(mock(Context.class)).build();
-    api = new FusedLocationProviderApiImpl(application);
-    api.connect(null);
+    api = new FusedLocationProviderApiImpl();
+    api.connect(application, null);
     service = api.getService();
   }
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
@@ -1,7 +1,6 @@
 package com.mapzen.android.lost.internal;
 
 import com.mapzen.android.lost.api.Geofence;
-import com.mapzen.android.lost.api.GeofencingApi;
 import com.mapzen.android.lost.api.GeofencingRequest;
 import com.mapzen.android.lost.api.LostApiClient;
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
@@ -27,13 +27,14 @@ import static org.mockito.Mockito.when;
 public class GeofencingApiTest {
   Context context;
   LocationManager locationManager;
-  GeofencingApi geofencingApi;
+  GeofencingApiImpl geofencingApi;
 
   @Before public void setUp() throws Exception {
     context = mock(Context.class);
     locationManager = mock(LocationManager.class);
     when(context.getSystemService(LOCATION_SERVICE)).thenReturn(locationManager);
-    geofencingApi = new GeofencingApiImpl(context);
+    geofencingApi = new GeofencingApiImpl();
+    geofencingApi.connect(context);
   }
 
   @Test public void shouldNotBeNull() throws Exception {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -29,7 +29,7 @@ import static org.robolectric.Shadows.shadowOf;
 public class LostApiClientImplTest {
   private LostApiClient client;
 
-  @Before public void setUp() {
+  @Before public void setUp() throws Exception {
     client = new LostApiClient.Builder(application).build();
 
     FusedLocationProviderService.FusedLocationProviderBinder stubBinder = mock(
@@ -40,48 +40,48 @@ public class LostApiClientImplTest {
 
   }
 
-  @After public void tearDown() {
+  @After public void tearDown() throws Exception {
     client.disconnect();
   }
 
-  @Test public void connect_shouldConnectFusedLocationProviderApiImpl() {
+  @Test public void connect_shouldConnectFusedLocationProviderApiImpl() throws Exception {
     client.connect();
     FusedLocationProviderApiImpl fusedApi =
         (FusedLocationProviderApiImpl) LocationServices.FusedLocationApi;
     assertThat(fusedApi.isConnected()).isTrue();
   }
 
-  @Test public void connect_shouldConnectGeofencingApiImpl() {
+  @Test public void connect_shouldConnectGeofencingApiImpl() throws Exception {
     client.connect();
     GeofencingApiImpl geofencingApi = (GeofencingApiImpl) LocationServices.GeofencingApi;
     assertThat(geofencingApi.isConnected()).isTrue();
   }
 
-  @Test public void connect_shouldConnectSettingsApiImpl() {
+  @Test public void connect_shouldConnectSettingsApiImpl() throws Exception {
     client.connect();
     SettingsApiImpl settingsApi = (SettingsApiImpl) LocationServices.SettingsApi;
     assertThat(settingsApi.isConnected()).isTrue();
   }
 
-  @Test public void disconnect_shouldNotRemoveFusedLocationProviderApiImpl() {
+  @Test public void disconnect_shouldNotRemoveFusedLocationProviderApiImpl() throws Exception {
     client.connect();
     client.disconnect();
     assertThat(LocationServices.FusedLocationApi).isNotNull();
   }
 
-  @Test public void disconnect_shouldNotRemoveGeofencingApiImpl() {
+  @Test public void disconnect_shouldNotRemoveGeofencingApiImpl() throws Exception {
     client.connect();
     client.disconnect();
     assertThat(LocationServices.GeofencingApi).isNotNull();
   }
 
-  @Test public void disconnect_shouldNotRemoveSettingsApiImpl() {
+  @Test public void disconnect_shouldNotRemoveSettingsApiImpl() throws Exception {
     client.connect();
     client.disconnect();
     assertThat(LocationServices.SettingsApi).isNotNull();
   }
 
-  @Test public void disconnect_shouldDisconnectFusedLocationProviderApiImpl() {
+  @Test public void disconnect_shouldDisconnectFusedLocationProviderApiImpl() throws Exception {
     client.connect();
     client.disconnect();
     FusedLocationProviderApiImpl fusedApi =
@@ -89,21 +89,21 @@ public class LostApiClientImplTest {
     assertThat(fusedApi.isConnected()).isFalse();
   }
 
-  @Test public void disconnect_shouldDisconnectGeofencingApiImpl() {
+  @Test public void disconnect_shouldDisconnectGeofencingApiImpl() throws Exception {
     client.connect();
     client.disconnect();
     GeofencingApiImpl geofencingApi = (GeofencingApiImpl) LocationServices.GeofencingApi;
     assertThat(geofencingApi.isConnected()).isFalse();
   }
 
-  @Test public void disconnect_shouldDisconnectSettingsApiImpl() {
+  @Test public void disconnect_shouldDisconnectSettingsApiImpl() throws Exception {
     client.connect();
     client.disconnect();
     SettingsApiImpl settingsApi = (SettingsApiImpl) LocationServices.SettingsApi;
     assertThat(settingsApi.isConnected()).isFalse();
   }
 
-  @Test public void disconnect_shouldUnregisterLocationUpdateListeners() {
+  @Test public void disconnect_shouldUnregisterLocationUpdateListeners() throws Exception {
     client.connect();
     LocationServices.FusedLocationApi.requestLocationUpdates(client, LocationRequest.create(),
         new LocationListener() {
@@ -122,7 +122,8 @@ public class LostApiClientImplTest {
     assertThat(shadowOf(lm).getRequestLocationUpdateListeners()).isEmpty();
   }
 
-  @Test public void disconnect_multipleClients_shouldNotRemoveFusedLocationProviderApiImpl() {
+  @Test public void disconnect_multipleClients_shouldNotRemoveFusedLocationProviderApiImpl()
+      throws Exception {
     LostApiClient anotherClient = new LostApiClient.Builder(application).build();
     anotherClient.connect();
     client.connect();
@@ -131,7 +132,7 @@ public class LostApiClientImplTest {
     anotherClient.disconnect();
   }
 
-  @Test public void disconnect_multipleClients_shouldNotRemoveGeofencingApiImpl() {
+  @Test public void disconnect_multipleClients_shouldNotRemoveGeofencingApiImpl() throws Exception {
     LostApiClient anotherClient = new LostApiClient.Builder(application).build();
     anotherClient.connect();
     client.connect();
@@ -140,7 +141,7 @@ public class LostApiClientImplTest {
     anotherClient.disconnect();
   }
 
-  @Test public void disconnect_multipleClients_shouldNotRemoveSettingsApiImpl() {
+  @Test public void disconnect_multipleClients_shouldNotRemoveSettingsApiImpl() throws Exception {
     LostApiClient anotherClient = new LostApiClient.Builder(application).build();
     anotherClient.connect();
     client.connect();
@@ -151,16 +152,16 @@ public class LostApiClientImplTest {
 
 
   @Test
-  public void isConnected_shouldReturnFalseBeforeConnected() {
+  public void isConnected_shouldReturnFalseBeforeConnected() throws Exception {
     assertThat(client.isConnected()).isFalse();
   }
 
-  @Test public void isConnected_shouldReturnTrueAfterConnected() {
+  @Test public void isConnected_shouldReturnTrueAfterConnected() throws Exception {
     client.connect();
     assertThat(client.isConnected()).isTrue();
   }
 
-  @Test public void isConnected_shouldReturnFalseAfterDisconnected() {
+  @Test public void isConnected_shouldReturnFalseAfterDisconnected() throws Exception {
     client.connect();
     client.disconnect();
     assertThat(client.isConnected()).isFalse();

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -1,6 +1,5 @@
 package com.mapzen.android.lost.internal;
 
-import com.mapzen.android.lost.api.FusedLocationProviderApi;
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LocationServices;


### PR DESCRIPTION
### Overview
This PR prevents the static APIs from being able to be modified by clients.

### Proposed Changes
- Make `LocationServices` fields final
- Add `connect()`, `isConnected()`, and `disconnect()` methods for all APIs
- Update `LostApiClientImpl` to use new `connect()`, `isConnected()`, and `disconnect()` methods for corresponding methods
- Update and add tests

Closes #33 

