### PR TITLE
Change checkstyle rules to allow for current version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,6 +2,13 @@
 
 Contributor guidelines for the Location Open Source Tracker project.
 
+First off, thanks for taking the time to contribute!
+
+## Aim
+This project seeks to provide an open source alternative to Google's [Fused Location Provider](https://developer.android.com/training/location/index.html), only depending on the Android SDK.
+Therefore, contributions should implement the [FusedLocationProviderAPI](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderApi) or fix bugs/improve the current implementation, rather than implementing completely new features.
+But a working subset is always fine. That's kind of what this project is all about ;).
+
 ## Prerequisites
 
 1. Android SDK with Tools, Extras, and API 23 installed.
@@ -9,53 +16,96 @@ Contributor guidelines for the Location Open Source Tracker project.
 
 ## Getting started
 
-1. Fork and clone the repository.
+1. Fork the project on GitHub.
+2. Clone the repository on your local development machine via Android Studio or the command line:
 
     ```
     git clone git@github.com:username/LOST.git
     ```
 
-2. Create a feature branch to make your changes.
+3. (Optional): Add the original repository as an additional remote to stay in touch with ongoing developments:
+
+    ```
+    git remote add --mirror=fetch upstream https://github.com/mapzen/LOST.git
+    ```
+
+4. Create a feature branch to make your changes:
 
     ```
     git checkout -b my-feature-name
     ```
 
-3. Implement your code and tests in your feature branch then push to your fork.
+5. Implement your code and tests in your feature branch.
+6. Push to your fork:
 
     ```
     git push origin my-feature-name
     ```
 
-4. Submit a pull request using GitHub's web interface.
+7. Submit a pull request using GitHub's web interface.
 
 ## Building and testing
 
-Execute the following Gradle tasks to run all tests and code style checks and install LOST to your local maven repository.
+Execute the following Gradle tasks to run all tests and code style checks and install LOST to your local maven repository:
 
     ./gradlew clean test checkstyle install
 
-Alternatively you can run the Gradle default tasks pre-configured in the root project `build.gradle`.
+Alternatively you can run the Gradle default tasks pre-configured in the root project `build.gradle`:
 
     ./gradlew
 
 ## Sample app
 
-Build and install the sample application on your USB device or emulator using the `installDebug` task.
+The project not only contains the library itself, but also a sample app for testing, debugging and guiding developers when using the library. It is only a rough user interface for demonstration purposes.
+When you commit a new feature, please consider to also provide a sample implementation of the new library interface.
+
+Build and install the sample application on your USB device or emulator using the `installDebug` task:
 
     ./gradlew installDebug
 
 ## Writing tests
 
 Good test coverage is an important guard against defects and regressions in the LOST framework. All classes should have unit test classes. All public methods should have unit tests. Those classes and methods should have all their possible states well tested.
+The optimal way would be to first write the test and then implement the code until the test succeeds.
+You can Right Click > "Run" on any test class in Android Studio directly in the editor to run it. Or you can run all tests via the "test" task in the Gradle tab of the GUI or on the command line with `./gradlew clean test`.
+Obviously, if the test case fails, the implementation needs to be fixed before committing/issuing a pull request.
 
 ## Code style
 
-Essentially the IntelliJ default Java style, but with two-space indents.
+Essentially the IntelliJ default Java style, but with two-space indents:
 
 1. Spaces, not tabs.
 2. Two space indent.
 3. Curly braces for everything: if, else, etc.
 4. One line of white space between methods.
 
-Code style config can be downloaded and installed from https://github.com/mapzen/java-code-styles.
+To help adhering to this, you can include the file [MapzenAndroid.xml](https://github.com/mapzen/java-code-styles/blob/master/configs/MapzenAndroid.xml) into the `config/codestyles/` (create it if not present yet) directory of your Android Studio profile (on Linux this is at `~/.AndroidStudio*/`), [see here for help](https://www.jetbrains.com/help/idea/2016.2/copying-code-style-settings.html).
+There is a script doing this for you at https://github.com/mapzen/java-code-styles.
+Afterwards, at "File > Settings > Editor > Code Style > Java" you can select the MapzenAndroid scheme at the top.
+
+Now, while you're working on the code, the editor will support you. Also, you can use "Code > Reformat Code" (<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>) from time to time.
+
+## Checkstyle
+As an additional measure, we use [Checkstyle](http://checkstyle.sourceforge.net/).
+You can run the checks defined in [config/checkstyle/checkstyle.xml](https://github.com/mapzen/LOST/blob/master/config/checkstyle/checkstyle.xml) either manually on the command line via `./gradlew checkstyle` or pick the task from the Gradle pane before pushing.
+It will generate a HTML file at `lost/build/reports/checkstyle/checkstyle.html` inside the project folder, listing all violations.
+You could also add a git pre commit hook.
+
+A maybe even more comfortable way is to install the [CheckStyle-IDEA plugin](https://plugins.jetbrains.com/plugin/1065) via "File->Settings->Plugins->Install JetBrains plugin".
+After the restart, navigate to "File > Settings > Other Settings > Checkstyle", click on the green <kbd>+</kbd> button on the right of the upper list, choose the checkstyle.xml from the project directory, select "Store relative to project location" and give it a description like "Mapzen LOST".
+Above the list, you can check all three additional checkboxes.
+
+Now, while editing code, failed checkstyle rules will show up like the usual Android Linter remarks.
+Also, there is a new tab/pane "Checkstyle" in the lower edge of the GUI, allowing to manually run the checks on the current or all files in the project, you can jump to the location by double clicking the entry.
+Additionally, you can select "Scan with Checkstyle" in the "Commit" dialogue.
+
+Checkstyle remarks should be fixed before issuing a pull request.
+
+## Managing upstream changes
+While you work on your feature branch, there may be changes happening on the upstream master. It is helpful to monitor them, by fetching from time to time.
+Please do not merge them into your branch, but instead [rebase your changes](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) before issuing the pull request.
+Personally we prefer rebase to merge commits since it makes changes easier to review and history a bit more tidy. 
+You can do the rebase from the command line or, in Android Studio, while you are on your branch, select "Rebase onto" from the context menu of the upstream master in the "Log" of the "Version Control" tab.
+You will probably (depending on how big the master changes and your's are) have to "Resolve conflicts" in the files separately (select from the context menu from the individual files shown in red under "Log", always finish by "Merge"), and afterwards select "Skip Commit in Rebasing" from the "VCS->Git" menu.
+More information on this is available at [IntelliJ](https://www.jetbrains.com/help/idea/2016.2/interactive-rebase.html) or [Youtube](https://www.youtube.com/watch?v=lILdMGa-r38).
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,8 +5,9 @@ Contributor guidelines for the Location Open Source Tracker project.
 First off, thanks for taking the time to contribute!
 
 ## Aim
-This project seeks to provide an open source alternative to Google's [Fused Location Provider](https://developer.android.com/training/location/index.html), only depending on the Android SDK.
-Therefore, contributions should implement the [FusedLocationProviderAPI](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderApi) or fix bugs/improve the current implementation, rather than implementing completely new features.
+This project seeks to provide an open source alternative to basically anything in Google's [com.google.android.gms.location](https://developers.google.com/android/reference/com/google/android/gms/location/package-summary) package, only depending on the Android SDK.
+Therefore, contributions should implement the [FusedLocationProviderAPI](https://developers.google.com/android/reference/com/google/android/gms/location/FusedLocationProviderApi), [GeoencingApi](https://developers.google.com/android/reference/com/google/android/gms/location/GeofencingApi) or [SettingsApi](https://developers.google.com/android/reference/com/google/android/gms/location/SettingsApi) or fix bugs/improve the current implementation, rather than implementing completely new features.
+
 But a working subset is always fine. That's kind of what this project is all about ;).
 
 ## Prerequisites
@@ -107,5 +108,5 @@ Please do not merge them into your branch, but instead [rebase your changes](htt
 Personally we prefer rebase to merge commits since it makes changes easier to review and history a bit more tidy. 
 You can do the rebase from the command line or, in Android Studio, while you are on your branch, select "Rebase onto" from the context menu of the upstream master in the "Log" of the "Version Control" tab.
 You will probably (depending on how big the master changes and your's are) have to "Resolve conflicts" in the files separately (select from the context menu from the individual files shown in red under "Log", always finish by "Merge"), and afterwards select "Skip Commit in Rebasing" from the "VCS->Git" menu.
-More information on this is available at [IntelliJ](https://www.jetbrains.com/help/idea/2016.2/interactive-rebase.html) or [Youtube](https://www.youtube.com/watch?v=lILdMGa-r38).
+More information on this is available at [IntelliJ](https://www.jetbrains.com/help/idea/2016.2/interactive-rebase.html).
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,8 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.2'
+    classpath 'com.android.tools.build:gradle:2.1.3'
+    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
   }
 }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -142,12 +142,6 @@
             <property name="severity" value="ignore"/>
         </module>
         <module name="MissingSwitchDefault"/>
-        <!-- Problem with finding exception types... -->
-        <module name="RedundantThrows">
-            <property name="allowUnchecked" value="true"/>
-            <property name="suppressLoadErrors" value="true"/>
-            <property name="severity" value="info"/>
-        </module>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 16 14:25:42 MDT 2016
+#Fri Aug 26 13:53:34 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/lost-sample/build.gradle
+++ b/lost-sample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.2'
+    classpath 'com.android.tools.build:gradle:2.1.3'
   }
 }
 
@@ -24,13 +24,13 @@ version = VERSION_NAME
 description = """LOST Sample"""
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.3"
+  compileSdkVersion 24
+  buildToolsVersion "24.0.1"
 
   defaultConfig {
     applicationId "com.example.lost"
     minSdkVersion 15
-    targetSdkVersion 23
+    targetSdkVersion 24
     versionCode 1
     versionName "1.0"
   }
@@ -49,7 +49,7 @@ task checkstyle(type: Checkstyle) {
 dependencies {
   compile project(':lost')
   compile 'com.mapzen.android:prefs-plus:1.0.0'
-  compile 'com.android.support:appcompat-v7:23.4.0'
+  compile 'com.android.support:appcompat-v7:24.2.0'
 }
 
 apply from: file('../gradle-mvn-push.gradle')

--- a/lost-sample/src/main/java/com/example/lost/FusedLocationApiActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/FusedLocationApiActivity.java
@@ -17,6 +17,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
@@ -101,8 +102,8 @@ public class FusedLocationApiActivity extends AppCompatActivity implements
     }
   }
 
-  @Override public void onRequestPermissionsResult(int requestCode, String[] permissions,
-      int[] grantResults) {
+  @Override public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                                   @NonNull int[] grantResults) {
     if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
       connect();
     } else {

--- a/lost/build.gradle
+++ b/lost/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.2'
+    classpath 'com.android.tools.build:gradle:2.1.3'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
   }
 }
@@ -23,8 +23,8 @@ allprojects {
 }
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.3"
+  compileSdkVersion 24
+  buildToolsVersion "24.0.1"
 
   defaultConfig {
     minSdkVersion 15
@@ -64,7 +64,7 @@ task checkstyle(type: Checkstyle) {
 }
 
 dependencies {
-  compile 'com.android.support:support-annotations:23.4.0'
+  compile 'com.android.support:support-annotations:24.2.0'
 
   testCompile 'com.google.guava:guava:18.0'
   testCompile 'junit:junit:4.12'

--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingEvent.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingEvent.java
@@ -1,0 +1,52 @@
+package com.mapzen.android.lost.api;
+
+import android.content.Intent;
+import android.location.Location;
+
+import java.util.List;
+
+public class GeofencingEvent {
+    private static final int NO_ERROR = -1;
+    private static final int NO_TRANSITION_ALERT = -1;
+
+    public static final int GEOFENCE_NOT_AVAILABLE = 1000;
+    public static final int GEOFENCE_TOO_MANY_GEOFENCES = 1001;
+    public static final int GEOFENCE_TOO_MANY_PENDING_INTENTS = 1002;
+
+    private GeofencingEvent() {
+
+    }
+
+    public static GeofencingEvent fromIntent(Intent intent) {
+        if (intent == null) {
+            return null;
+        } else {
+            return new GeofencingEvent();
+        }
+    }
+
+    public int getErrorCode() {
+        if (!hasError()) {
+            return NO_ERROR;
+        }
+        return 0;
+    }
+
+    public int getGeofenceTransition() {
+        return NO_TRANSITION_ALERT;
+    }
+
+    public List<Geofence> getTriggeringGeofences() {
+        //return new ArrayList<Geofence>();
+        return null;
+    }
+
+    public Location getTriggeringLocation() {
+        //return new Location("");
+        return null;
+    }
+
+    public boolean hasError() {
+        return false;
+    }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingRequest.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingRequest.java
@@ -31,5 +31,13 @@ public class GeofencingRequest {
       geofences.add(geofence);
       return this;
     }
+
+    public GeofencingRequest.Builder addGeofences(List<Geofence> geofences) {
+      if (geofences == null) {
+        throw new IllegalArgumentException("Geofence cannot be null");
+      }
+      this.geofences.addAll(geofences);
+      return this;
+    }
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
@@ -5,10 +5,13 @@ import com.mapzen.android.lost.api.GeofencingApi;
 import com.mapzen.android.lost.api.GeofencingRequest;
 import com.mapzen.android.lost.api.LostApiClient;
 
+import android.Manifest;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.location.LocationManager;
+import android.support.annotation.RequiresPermission;
 
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -17,34 +20,67 @@ import java.util.List;
 public class GeofencingApiImpl implements GeofencingApi {
 
   private final LocationManager locationManager;
+  private final HashMap<String, PendingIntent> pendingIntentMap;
 
   GeofencingApiImpl(Context context) {
     locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+    pendingIntentMap = new HashMap<>();
   }
 
+  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION,
+          Manifest.permission.ACCESS_FINE_LOCATION})
   @Override
   public void addGeofences(LostApiClient client, GeofencingRequest geofencingRequest,
       PendingIntent pendingIntent)
       throws SecurityException {
-    ParcelableGeofence geofence = (ParcelableGeofence) geofencingRequest.getGeofences().get(0);
-    locationManager.addProximityAlert(
-        geofence.getLatitude(),
-        geofence.getLongitude(),
-        geofence.getRadius(),
-        geofence.getDuration(),
-        pendingIntent);
+    List<Geofence> geofences = geofencingRequest.getGeofences();
+    addGeofences(client, geofences, pendingIntent);
   }
 
+  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION})
   @Override public void addGeofences(LostApiClient client, List<Geofence> geofences,
-      PendingIntent pendingIntent) {
-    throw new RuntimeException("Sorry, not yet implemented");
+      PendingIntent pendingIntent)
+      throws SecurityException {
+    for (Geofence geofence : geofences) {
+      addGeofence(client, geofence, pendingIntent);
+    }
   }
 
+  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION})
+  private void addGeofence(LostApiClient client, Geofence geofence, PendingIntent pendingIntent)
+          throws SecurityException {
+    ParcelableGeofence pGeofence = (ParcelableGeofence) geofence;
+    String requestId = String.valueOf(pGeofence.hashCode());
+    locationManager.addProximityAlert(
+            pGeofence.getLatitude(),
+            pGeofence.getLongitude(),
+            pGeofence.getRadius(),
+            pGeofence.getDuration(),
+            pendingIntent);
+    if (pGeofence.getRequestId() != null && !pGeofence.getRequestId().isEmpty()) {
+      requestId = pGeofence.getRequestId();
+    }
+    pendingIntentMap.put(requestId, pendingIntent);
+  }
+
+  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION})
   @Override public void removeGeofences(LostApiClient client, List<String> geofenceRequestIds) {
-    throw new RuntimeException("Sorry, not yet implemented");
+    for (String geofenceRequestId : geofenceRequestIds) {
+      removeGeofences(client, geofenceRequestId);
+    }
   }
 
-  @Override public void removeGeofences(LostApiClient client, PendingIntent pendingIntent) {
-    throw new RuntimeException("Sorry, not yet implemented");
+  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION})
+  private void removeGeofences(LostApiClient client, String geofenceRequestId)
+      throws SecurityException {
+    PendingIntent pendingIntent = pendingIntentMap.get(geofenceRequestId);
+    removeGeofences(client, pendingIntent);
+  }
+
+  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION})
+  @Override public void removeGeofences(LostApiClient client, PendingIntent pendingIntent)
+    throws SecurityException {
+      locationManager.removeProximityAlert(pendingIntent);
+      pendingIntentMap.values().remove(pendingIntent);
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/ParcelableGeofence.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/ParcelableGeofence.java
@@ -11,7 +11,7 @@ public class ParcelableGeofence implements Geofence, Parcelable {
   private double latitude;
   private double longitude;
   private float radius;
-  private long durationMillis;
+  private long durationMillis = NEVER_EXPIRE;
 
   public ParcelableGeofence(String requestId, double latitude, double longitude, float radius,
       long durationMillis) {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusionEngineTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusionEngineTest.java
@@ -290,12 +290,14 @@ public class FusionEngineTest {
   @Test public void isBetterThan_shouldReturnFalseIfLocationAIsNull() throws Exception {
     Location locationA = null;
     Location locationB = new Location("test");
+    //noinspection ConstantConditions
     assertThat(FusionEngine.isBetterThan(locationA, locationB)).isFalse();
   }
 
   @Test public void isBetterThan_shouldReturnTrueIfLocationBIsNull() throws Exception {
     Location locationA = new Location("test");
     Location locationB = null;
+    //noinspection ConstantConditions
     assertThat(FusionEngine.isBetterThan(locationA, locationB)).isTrue();
   }
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
@@ -13,6 +13,9 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.location.LocationManager;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static android.content.Context.LOCATION_SERVICE;
 import static com.mapzen.android.lost.api.Geofence.NEVER_EXPIRE;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -39,16 +42,67 @@ public class GeofencingApiTest {
 
   @Test public void addGeofences_shouldAddProximityAlert() throws Exception {
     LostApiClient client = new LostApiClient.Builder(context).build();
+    Geofence geofence = new Geofence.Builder().setRequestId("test_id")
+        .setCircularRegion(1, 2, 3)
+        .setExpirationDuration(NEVER_EXPIRE)
+        .build();
+    GeofencingRequest request = new GeofencingRequest.Builder().addGeofence(geofence).build();
+    PendingIntent intent = Mockito.mock(PendingIntent.class);
+    geofencingApi.addGeofences(client, request, intent);
+    Mockito.verify(locationManager, times(1)).addProximityAlert(1, 2, 3, NEVER_EXPIRE, intent);
+  }
+
+  //as suggested here: https://github.com/mapzen/LOST/pull/88#discussion_r77384417
+  @Test public void addGeofencesArray_shouldAddProximityAlert() {
+    LostApiClient client = new LostApiClient.Builder(context).build();
+
     Geofence geofence = new Geofence.Builder()
         .setRequestId("test_id")
         .setCircularRegion(1, 2, 3)
         .setExpirationDuration(NEVER_EXPIRE)
         .build();
-    GeofencingRequest request = new GeofencingRequest.Builder()
-        .addGeofence(geofence)
+    Geofence anotherGeofence = new Geofence.Builder()
+        .setRequestId("test_id_1")
+        .setCircularRegion(4, 5, 6)
+        .setExpirationDuration(NEVER_EXPIRE)
         .build();
+    ArrayList<Geofence> geofences = new ArrayList<>();
+    geofences.add(geofence);
+    geofences.add(anotherGeofence);
     PendingIntent intent = Mockito.mock(PendingIntent.class);
-    geofencingApi.addGeofences(client, request, intent);
+    geofencingApi.addGeofences(client, geofences, intent);
     Mockito.verify(locationManager, times(1)).addProximityAlert(1, 2, 3, NEVER_EXPIRE, intent);
+    Mockito.verify(locationManager, times(1)).addProximityAlert(4, 5, 6, NEVER_EXPIRE, intent);
   }
+
+  @Test public void removeGeofence_pendingIntent_shouldRemoveProximityAlert() {
+    LostApiClient client = new LostApiClient.Builder(context).build();
+
+    PendingIntent intent = Mockito.mock(PendingIntent.class);
+    geofencingApi.removeGeofences(client, intent);
+    Mockito.verify(locationManager, times(1)).removeProximityAlert(intent);
+  }
+
+  @Test public void removeGeofences_ListOfString_shouldRemoveProximityAlert() {
+    LostApiClient client = new LostApiClient.Builder(context).build();
+
+    Geofence geofence = new Geofence.Builder()
+        .setRequestId("test_id")
+        .setCircularRegion(1, 2, 3)
+        .setExpirationDuration(NEVER_EXPIRE)
+        .build();
+    List<Geofence> geofenceList = new ArrayList<>();
+    geofenceList.add(geofence);
+
+    List<String> idList = new ArrayList<>();
+    idList.add("test_id");
+
+    PendingIntent intent = Mockito.mock(PendingIntent.class);
+
+    geofencingApi.addGeofences(client, geofenceList, intent);
+    geofencingApi.removeGeofences(client, idList);
+
+    Mockito.verify(locationManager, times(1)).removeProximityAlert(intent);
+  }
+
 }


### PR DESCRIPTION
### Overview
Hi, I wanted to use Checkstyle directly from within the Android Studio GUI, so hints can be displayed while coding, I thought that might make it easier to adhere to the style.

The current plugin (https://plugins.jetbrains.com/plugin/1065, 4.31.0, 2016-08-06) comes with Checkstyle 7.1/31 Jul 2016, but the rule `RedundantThrows`, used in `config/checkstyle/checkstyle.xml`
 is not being supported any more by Checkstyle since v. 6.2/28 Dec 2014 (because it is said to be an "Example of really buggy Check", see https://github.com/checkstyle/checkstyle/issues/473#issuecomment-91093541 and http://checkstyle.sourceforge.net/releasenotes.html#Release_6.2).

I tried using an outdated version of the plugin (4.14.3, 2015-03-14, https://plugins.jetbrains.com/update/index?pr=&updateId=18978) with the old Checkstyle, which works, but I guess it would be better to use the current versions and remove the rule, since it is buggy anyways?

Also, it took me some time to get around setting and using code style and Checkstyle rules in Android Studio, so I thought why not write it up for others to come.
I hope, it's not too intrusive for a contributor to change the contributing guidelines...?

### Proposed Changes
- Remove `RedundantThrows` from Checkstyle to allow for latest version
- Add some information to the contributing guidelines