### PR TITLE
Adds "android-24" to Circle CI dependencies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   pre:
-    - echo y | android update sdk --all --no-ui --force --filter "build-tools-23.0.3,android-24,extra-android-m2repository"
+    - echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.1,android-24,extra-android-m2repository"
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+machine:
+  java:
+    version: oraclejdk8
+
 dependencies:
   pre:
     - echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.1,android-24,extra-android-m2repository"

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   pre:
-    - echo y | android update sdk --all --no-ui --force --filter "build-tools-23.0.3,extra-android-m2repository"
+    - echo y | android update sdk --all --no-ui --force --filter "build-tools-23.0.3,android-24,extra-android-m2repository"
 
 test:
   override:

--- a/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
@@ -5,7 +5,6 @@ import com.mapzen.android.lost.api.GeofencingApi;
 import com.mapzen.android.lost.api.GeofencingRequest;
 import com.mapzen.android.lost.api.LostApiClient;
 
-import android.Manifest;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.location.LocationManager;
@@ -13,6 +12,9 @@ import android.support.annotation.RequiresPermission;
 
 import java.util.HashMap;
 import java.util.List;
+
+import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
+import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
 /**
  * Implementation of the {@link GeofencingApi}.
@@ -27,8 +29,7 @@ public class GeofencingApiImpl implements GeofencingApi {
     pendingIntentMap = new HashMap<>();
   }
 
-  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION,
-          Manifest.permission.ACCESS_FINE_LOCATION})
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   @Override
   public void addGeofences(LostApiClient client, GeofencingRequest geofencingRequest,
       PendingIntent pendingIntent)
@@ -37,7 +38,7 @@ public class GeofencingApiImpl implements GeofencingApi {
     addGeofences(client, geofences, pendingIntent);
   }
 
-  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION})
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   @Override public void addGeofences(LostApiClient client, List<Geofence> geofences,
       PendingIntent pendingIntent)
       throws SecurityException {
@@ -46,7 +47,7 @@ public class GeofencingApiImpl implements GeofencingApi {
     }
   }
 
-  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION})
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   private void addGeofence(LostApiClient client, Geofence geofence, PendingIntent pendingIntent)
           throws SecurityException {
     ParcelableGeofence pGeofence = (ParcelableGeofence) geofence;
@@ -63,21 +64,21 @@ public class GeofencingApiImpl implements GeofencingApi {
     pendingIntentMap.put(requestId, pendingIntent);
   }
 
-  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION})
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   @Override public void removeGeofences(LostApiClient client, List<String> geofenceRequestIds) {
     for (String geofenceRequestId : geofenceRequestIds) {
       removeGeofences(client, geofenceRequestId);
     }
   }
 
-  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION})
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   private void removeGeofences(LostApiClient client, String geofenceRequestId)
       throws SecurityException {
     PendingIntent pendingIntent = pendingIntentMap.get(geofenceRequestId);
     removeGeofences(client, pendingIntent);
   }
 
-  @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION})
+  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   @Override public void removeGeofences(LostApiClient client, PendingIntent pendingIntent)
     throws SecurityException {
       locationManager.removeProximityAlert(pendingIntent);


### PR DESCRIPTION
### Overview

Fixes failing build on Circle CI by adding `android-24`, `build-tools-24.0.1` , and `oraclejdk8` to build config and fixing checkstyle errors.

### Proposed Changes

* Adds `android-24` and `build-tools-24.0.1` to Circle CI dependencies.
* Configures the Circle CI build machine to use `oraclejdk8` as Java 8 is required for Android 24.
* Fixes checkstyle (line >100 characters) errors by adding static imports for manifest permissions.