### PR TITLE
Add PendingResult to GeofencingApi

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingApi.java
@@ -11,15 +11,16 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 public interface GeofencingApi {
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  void addGeofences(LostApiClient client, GeofencingRequest geofencingRequest,
+  PendingResult<Status> addGeofences(LostApiClient client, GeofencingRequest geofencingRequest,
       PendingIntent pendingIntent);
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  void addGeofences(LostApiClient client, List<Geofence> geofences, PendingIntent pendingIntent);
+  PendingResult<Status> addGeofences(LostApiClient client, List<Geofence> geofences,
+      PendingIntent pendingIntent);
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  void removeGeofences(LostApiClient client, List<String> geofenceRequestIds);
+  PendingResult<Status> removeGeofences(LostApiClient client, List<String> geofenceRequestIds);
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  void removeGeofences(LostApiClient client, PendingIntent pendingIntent);
+  PendingResult<Status> removeGeofences(LostApiClient client, PendingIntent pendingIntent);
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
@@ -56,63 +56,63 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
       LocationListener listener) {
     clientManager.addListener(client, request, listener);
     locationEngine.setRequest(request);
-    return new FusedLocationPendingResult(true);
+    return new SimplePendingResult(true);
   }
 
   public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       PendingIntent callbackIntent) {
     clientManager.addPendingIntent(client, request, callbackIntent);
     locationEngine.setRequest(request);
-    return new FusedLocationPendingResult(true);
+    return new SimplePendingResult(true);
   }
 
   public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       LocationCallback callback, Looper looper) {
     clientManager.addLocationCallback(client, request, callback, looper);
     locationEngine.setRequest(request);
-    return new FusedLocationPendingResult(true);
+    return new SimplePendingResult(true);
   }
 
   public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       LocationListener listener) {
     boolean hasResult = clientManager.removeListener(client, listener);
     checkAllListenersPendingIntentsAndCallbacks();
-    return new FusedLocationPendingResult(hasResult);
+    return new SimplePendingResult(hasResult);
   }
 
   public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       PendingIntent callbackIntent) {
     boolean hasResult = clientManager.removePendingIntent(client, callbackIntent);
     checkAllListenersPendingIntentsAndCallbacks();
-    return new FusedLocationPendingResult(hasResult);
+    return new SimplePendingResult(hasResult);
   }
 
   public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       LocationCallback callback) {
     boolean hasResult = clientManager.removeLocationCallback(client, callback);
     checkAllListenersPendingIntentsAndCallbacks();
-    return new FusedLocationPendingResult(hasResult);
+    return new SimplePendingResult(hasResult);
   }
 
   public PendingResult<Status> setMockMode(LostApiClient client, boolean isMockMode) {
     if (mockMode != isMockMode) {
       toggleMockMode();
     }
-    return new FusedLocationPendingResult(true);
+    return new SimplePendingResult(true);
   }
 
   public PendingResult<Status> setMockLocation(LostApiClient client, Location mockLocation) {
     if (mockMode) {
       ((MockEngine) locationEngine).setLocation(mockLocation);
     }
-    return new FusedLocationPendingResult(true);
+    return new SimplePendingResult(true);
   }
 
   public PendingResult<Status> setMockTrace(LostApiClient client, File file) {
     if (mockMode) {
       ((MockEngine) locationEngine).setTrace(file);
     }
-    return new FusedLocationPendingResult(true);
+    return new SimplePendingResult(true);
   }
 
   public boolean isProviderEnabled(LostApiClient client, String provider) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/SimplePendingResult.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/SimplePendingResult.java
@@ -9,11 +9,11 @@ import android.support.annotation.NonNull;
 
 import java.util.concurrent.TimeUnit;
 
-public class FusedLocationPendingResult extends PendingResult<Status> {
+public class SimplePendingResult extends PendingResult<Status> {
 
   private boolean hasResult = false;
 
-  public FusedLocationPendingResult(boolean hasResult) {
+  public SimplePendingResult(boolean hasResult) {
     this.hasResult = hasResult;
   }
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/SimplePendingResultTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/SimplePendingResultTest.java
@@ -8,9 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
-public class FusedLocationPendingResultTest {
+public class SimplePendingResultTest {
 
-  FusedLocationPendingResult result = new FusedLocationPendingResult(true);
+  SimplePendingResult result = new SimplePendingResult(true);
 
   @Test public void await_shouldReturnSuccess() {
     assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);


### PR DESCRIPTION
### Overview
Adds `PendingResult` to `GeofencingApi`

### Proposed Changes
- Returns `PendingResult` object for all API calls to `GeofencingApi`
- Refactors `FusedLocationPendingResult` to `SimplePendingResult` to be shared by `FusedLocationProviderApi` and `GeofencingApi`

Closes #99 