### PR TITLE
Update build tools and support libs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   pre:
-    - echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.1,android-24,extra-android-m2repository"
+    - echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.2,android-24,extra-android-m2repository"
 
 test:
   override:

--- a/lost-sample/build.gradle
+++ b/lost-sample/build.gradle
@@ -25,7 +25,7 @@ description = """LOST Sample"""
 
 android {
   compileSdkVersion 24
-  buildToolsVersion "24.0.1"
+  buildToolsVersion "24.0.2"
 
   defaultConfig {
     applicationId "com.example.lost"
@@ -49,7 +49,7 @@ task checkstyle(type: Checkstyle) {
 dependencies {
   compile project(':lost')
   compile 'com.mapzen.android:prefs-plus:1.0.0'
-  compile 'com.android.support:appcompat-v7:24.2.0'
+  compile 'com.android.support:appcompat-v7:24.2.1'
 }
 
 apply from: file('../gradle-mvn-push.gradle')

--- a/lost/build.gradle
+++ b/lost/build.gradle
@@ -24,7 +24,7 @@ allprojects {
 
 android {
   compileSdkVersion 24
-  buildToolsVersion "24.0.1"
+  buildToolsVersion "24.0.2"
 
   defaultConfig {
     minSdkVersion 15
@@ -64,7 +64,7 @@ task checkstyle(type: Checkstyle) {
 }
 
 dependencies {
-  compile 'com.android.support:support-annotations:24.2.0'
+  compile 'com.android.support:support-annotations:24.2.1'
 
   testCompile 'com.google.guava:guava:18.0'
   testCompile 'junit:junit:4.12'


### PR DESCRIPTION
### Overview

Update Android build tools and support libs to latest versions.

### Proposed Changes

* Build tools version 24.0.2
* Support annotations and appcompat version 24.2.1
