### PR TITLE
100 geofencing event extra

### DIFF
--- a/lost/src/main/AndroidManifest.xml
+++ b/lost/src/main/AndroidManifest.xml
@@ -17,6 +17,11 @@
     <activity android:name="com.mapzen.android.lost.internal.ResolveLocationActivity"/>
 
     <service android:name="com.mapzen.android.lost.internal.FusedLocationProviderService"/>
+    <service android:name="com.mapzen.android.lost.api.GeofencingIntentService">
+      <intent-filter>
+        <action android:name="com.mapzen.lost.action.ACTION_GEOFENCING_SERVICE"/>
+      </intent-filter>
+    </service>
 
   </application>
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingApi.java
@@ -10,6 +10,10 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
 public interface GeofencingApi {
 
+  String EXTRA_TRANSITION = "com.mapzen.lost.extra.transition";
+  String EXTRA_GEOFENCE_LIST = "com.mapzen.lost.extra.geofence_list";
+  String EXTRA_TRIGGERING_LOCATION = "com.mapzen.lost.extra.triggering_location";
+
   /**
    * Sets {@link PendingIntent} to be notified when the device enters or exits one of the specified
    * geofences.

--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingApi.java
@@ -10,8 +10,22 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
 public interface GeofencingApi {
 
+  /**
+   * Extra passed in {@link android.content.Intent} that is fired when requesting proximity
+   * updates. Value is an integer.
+   */
   String EXTRA_TRANSITION = "com.mapzen.lost.extra.transition";
+
+  /**
+   * Extra passed in {@link android.content.Intent} that is fired when requesting proximity
+   * updates. Value is array of {@link Geofence} objects.
+   */
   String EXTRA_GEOFENCE_LIST = "com.mapzen.lost.extra.geofence_list";
+
+  /**
+   * Extra passed in {@link android.content.Intent} that is fired when requesting proximity
+   * updates. Value is {@link android.location.Location} object.
+   */
   String EXTRA_TRIGGERING_LOCATION = "com.mapzen.lost.extra.triggering_location";
 
   /**

--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentSender.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentSender.java
@@ -6,7 +6,6 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
-import android.location.LocationManager;
 import android.os.Bundle;
 
 import java.util.ArrayList;
@@ -16,7 +15,8 @@ import static com.mapzen.android.lost.api.GeofencingIntentService.EXTRA_PENDING_
 
 /**
  * Handles generating an intent populated with relevant extras from an {@link Intent} fired by
- * {@link LocationManager#addProximityAlert(double, double, float, long, PendingIntent)}
+ * {@link android.location.LocationManager#addProximityAlert(double, double, float, long,
+ * PendingIntent)}
  */
 public class GeofencingIntentSender {
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentSender.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentSender.java
@@ -1,0 +1,62 @@
+package com.mapzen.android.lost.api;
+
+import com.mapzen.android.lost.internal.FusionEngine;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.location.Location;
+import android.location.LocationManager;
+import android.os.Bundle;
+
+import java.util.ArrayList;
+
+import static com.mapzen.android.lost.api.GeofencingIntentService.EXTRA_GEOFENCE;
+import static com.mapzen.android.lost.api.GeofencingIntentService.EXTRA_PENDING_INTENT;
+
+/**
+ * Handles generating an intent populated with relevant extras from an {@link Intent} fired by
+ * {@link LocationManager#addProximityAlert(double, double, float, long, PendingIntent)}
+ */
+public class GeofencingIntentSender {
+
+  public static final String EXTRA_ENTERING = "entering";
+
+  private Context context;
+  private FusionEngine engine;
+
+  public GeofencingIntentSender(Context context) {
+    this.context = context;
+    engine = new FusionEngine(context, null);
+  }
+
+  public void sendIntent(Intent intent) {
+    Intent toSend = generateIntent(intent, engine.getLastLocation());
+    Bundle extras = intent.getExtras();
+    PendingIntent pendingIntent = (PendingIntent) extras.get(EXTRA_PENDING_INTENT);
+    try {
+      pendingIntent.send(context, 0, toSend);
+    } catch (PendingIntent.CanceledException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public Intent generateIntent(Intent intent, Location location) {
+    Bundle extras = intent.getExtras();
+
+    int transition = 0;
+    if (extras.containsKey(EXTRA_ENTERING)) {
+      transition = Geofence.GEOFENCE_TRANSITION_ENTER;
+    }
+
+    Geofence geofence = (Geofence) extras.get(EXTRA_GEOFENCE);
+    ArrayList<Geofence> geofences = new ArrayList<>();
+    geofences.add(geofence);
+
+    Intent toSend = new Intent();
+    toSend.putExtra(GeofencingApi.EXTRA_TRANSITION, transition);
+    toSend.putExtra(GeofencingApi.EXTRA_GEOFENCE_LIST, geofences);
+    toSend.putExtra(GeofencingApi.EXTRA_TRIGGERING_LOCATION, location);
+    return toSend;
+  }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentService.java
@@ -1,13 +1,13 @@
 package com.mapzen.android.lost.api;
 
 import android.app.IntentService;
-import android.app.PendingIntent;
 import android.content.Intent;
 
 /**
  * Handles receiving proximity alerts triggered by the {@link android.location.LocationManager} and
- * adds extras to the {@link PendingIntent} that is fired to the original caller as called from
- * {@link GeofencingApi#addGeofences(LostApiClient, GeofencingRequest, PendingIntent)}
+ * adds extras to the {@link android.app.PendingIntent} that is fired to the original caller as
+ * called from {@link GeofencingApi#addGeofences(LostApiClient, GeofencingRequest,
+ * android.app.PendingIntent)}
  */
 public class GeofencingIntentService extends IntentService {
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentService.java
@@ -1,0 +1,31 @@
+package com.mapzen.android.lost.api;
+
+import android.app.IntentService;
+import android.app.PendingIntent;
+import android.content.Intent;
+
+/**
+ * Handles receiving proximity alerts triggered by the {@link android.location.LocationManager} and
+ * adds extras to the {@link PendingIntent} that is fired to the original caller as called from
+ * {@link GeofencingApi#addGeofences(LostApiClient, GeofencingRequest, PendingIntent)}
+ */
+public class GeofencingIntentService extends IntentService {
+
+  public static final String ACTION_GEOFENCING_SERVICE =
+      "com.mapzen.lost.action.ACTION_GEOFENCING_SERVICE";
+
+  public static final String EXTRA_PENDING_INTENT = "pending_intent";
+  public static final String EXTRA_GEOFENCE = "geofence";
+
+  public GeofencingIntentService() {
+    super("GeofencingIntentService");
+  }
+
+  private GeofencingIntentSender intentGenerator =
+      new GeofencingIntentSender(this);
+
+  @Override protected void onHandleIntent(Intent intent) {
+    intentGenerator.sendIntent(intent);
+  }
+
+}

--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentService.java
@@ -6,7 +6,8 @@ import android.content.Intent;
 /**
  * Handles receiving proximity alerts triggered by the {@link android.location.LocationManager} and
  * adds extras to the {@link android.app.PendingIntent} that is fired to the original caller as
- * called from {@link GeofencingApi#addGeofences(LostApiClient, GeofencingRequest, android.app.PendingIntent)}
+ * called from {@link GeofencingApi#addGeofences(LostApiClient, GeofencingRequest,
+ * android.app.PendingIntent)}
  */
 public class GeofencingIntentService extends IntentService {
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentService.java
@@ -6,8 +6,7 @@ import android.content.Intent;
 /**
  * Handles receiving proximity alerts triggered by the {@link android.location.LocationManager} and
  * adds extras to the {@link android.app.PendingIntent} that is fired to the original caller as
- * called from {@link GeofencingApi#addGeofences(LostApiClient, GeofencingRequest,
- * android.app.PendingIntent)}
+ * called from {@link GeofencingApi#addGeofences(LostApiClient, GeofencingRequest, android.app.PendingIntent)}
  */
 public class GeofencingIntentService extends IntentService {
 
@@ -21,10 +20,8 @@ public class GeofencingIntentService extends IntentService {
     super("GeofencingIntentService");
   }
 
-  private GeofencingIntentSender intentGenerator =
-      new GeofencingIntentSender(this);
-
   @Override protected void onHandleIntent(Intent intent) {
+    GeofencingIntentSender intentGenerator = new GeofencingIntentSender(this);
     intentGenerator.sendIntent(intent);
   }
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationServices.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationServices.java
@@ -2,6 +2,7 @@ package com.mapzen.android.lost.api;
 
 import com.mapzen.android.lost.internal.FusedLocationProviderApiImpl;
 import com.mapzen.android.lost.internal.GeofencingApiImpl;
+import com.mapzen.android.lost.internal.GeofencingServiceIntentFactory;
 import com.mapzen.android.lost.internal.SettingsApiImpl;
 
 /**
@@ -18,7 +19,8 @@ public class LocationServices {
   /**
    * Entry point for APIs concerning geofences.
    */
-  public static final GeofencingApi GeofencingApi = new GeofencingApiImpl();
+  public static final GeofencingApi GeofencingApi = new GeofencingApiImpl(
+      new GeofencingServiceIntentFactory());
 
   /**
    * Entry point for APIs concerning location settings.

--- a/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
@@ -74,7 +74,8 @@ public class GeofencingApiImpl implements GeofencingApi {
     internalIntent.putExtra(GeofencingIntentService.EXTRA_PENDING_INTENT, pendingIntent);
     ParcelableGeofence pGeofence = (ParcelableGeofence) geofence;
     internalIntent.putExtra(GeofencingIntentService.EXTRA_GEOFENCE, pGeofence);
-    PendingIntent internalPendingIntent = intentFactory.createPendingIntent(context, internalIntent);
+    PendingIntent internalPendingIntent = intentFactory.createPendingIntent(context,
+        internalIntent);
 
     String requestId = String.valueOf(pGeofence.hashCode());
     locationManager.addProximityAlert(

--- a/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingServiceIntentFactory.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingServiceIntentFactory.java
@@ -1,0 +1,18 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.GeofencingIntentService;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+public class GeofencingServiceIntentFactory implements IntentFactory {
+
+  @Override public Intent createIntent() {
+    return new Intent(GeofencingIntentService.ACTION_GEOFENCING_SERVICE);
+  }
+
+  @Override public PendingIntent createPendingIntent(Context context, Intent intent) {
+    return PendingIntent.getService(context, 1, intent, 0);
+  }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/internal/IntentFactory.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/IntentFactory.java
@@ -1,0 +1,10 @@
+package com.mapzen.android.lost.internal;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+public interface IntentFactory {
+  Intent createIntent();
+  PendingIntent createPendingIntent(Context context, Intent intent);
+}

--- a/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
@@ -1,47 +1,29 @@
 package com.mapzen.android.lost.internal;
 
 import com.mapzen.android.lost.api.Geofence;
-import com.mapzen.android.lost.api.GeofencingApi;
-import com.mapzen.android.lost.api.GeofencingIntentService;
 import com.mapzen.android.lost.api.GeofencingRequest;
-import com.mapzen.android.lost.api.LocationAvailability;
-import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.android.lost.api.PendingResult;
 import com.mapzen.android.lost.api.Status;
-import com.mapzen.lost.BuildConfig;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricGradleTestRunner;
-import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowApplication;
 
 import android.app.PendingIntent;
-import android.app.Service;
 import android.content.Context;
-import android.content.Intent;
-import android.location.Location;
 import android.location.LocationManager;
-import android.os.IBinder;
-import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static android.content.Context.LOCATION_SERVICE;
-import static android.location.LocationManager.NETWORK_PROVIDER;
 import static com.mapzen.android.lost.api.Geofence.NEVER_EXPIRE;
-import static com.mapzen.android.lost.api.LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY;
 import static org.fest.assertions.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
-import static org.robolectric.RuntimeEnvironment.application;
 
 @SuppressWarnings("MissingPermission")
 public class GeofencingApiTest {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingIntentSenderTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingIntentSenderTest.java
@@ -1,0 +1,52 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.Geofence;
+import com.mapzen.android.lost.api.GeofencingApi;
+import com.mapzen.android.lost.api.GeofencingIntentSender;
+import com.mapzen.android.lost.api.GeofencingIntentService;
+import com.mapzen.lost.BuildConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import android.content.Context;
+import android.content.Intent;
+import android.location.Location;
+import android.os.Bundle;
+
+import java.util.ArrayList;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
+public class GeofencingIntentSenderTest {
+
+  GeofencingIntentSender intentSender;
+
+  @Before public void setup() {
+    intentSender = new GeofencingIntentSender(mock(Context.class));
+  }
+
+  @Test public void generateIntent_shouldHaveExtras() {
+    Intent intent = new Intent("");
+    Bundle extras = new Bundle();
+    extras.putInt(GeofencingIntentSender.EXTRA_ENTERING, 1);
+    ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000);
+    extras.putParcelable(GeofencingIntentService.EXTRA_GEOFENCE, geofence);
+    intent.putExtras(extras);
+
+    Location location = new Location("");
+    Intent generated = intentSender.generateIntent(intent, location);
+    ArrayList geofences = (ArrayList) generated.getExtras().get(GeofencingApi.EXTRA_GEOFENCE_LIST);
+    assertThat(geofences.get(0)).isEqualTo(geofence);
+    assertThat(generated.getExtras().get(GeofencingApi.EXTRA_TRANSITION)).isEqualTo(
+        Geofence.GEOFENCE_TRANSITION_ENTER);
+    assertThat(generated.getExtras().get(GeofencingApi.EXTRA_TRIGGERING_LOCATION)).isEqualTo(
+        location);
+  }
+}

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestIntentFactory.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestIntentFactory.java
@@ -1,0 +1,21 @@
+package com.mapzen.android.lost.internal;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+import static org.mockito.Mockito.mock;
+
+public class TestIntentFactory implements IntentFactory {
+
+  Intent intent = mock(Intent.class);
+  PendingIntent pendingIntent = mock(PendingIntent.class);
+
+  @Override public Intent createIntent() {
+    return intent;
+  }
+
+  @Override public PendingIntent createPendingIntent(Context context, Intent intent) {
+    return pendingIntent;
+  }
+}


### PR DESCRIPTION
### Overview
This PR adds 3 extras to be sent in the `PendingIntent` fired from calls to `GeofencingApi#addGeofence`

### Proposed Changes
Like a familiar library also does, this change adds extras `EXTRA_TRANSITION `, `EXTRA_GEOFENCE_LIST `, `EXTRA_TRIGGERING_LOCATION ` to all intents fired by the `GeofencingApi`.

Nuances:
- At the moment the EXTRA_TRANSITION, will always be 1 because I only seem to be getting "entering" information from the intent fired by `LocationManager`.
- EXTRA_TRIGGERING_LOCATION is the location returned by `FusionEngine#getLastLocation()`

Closes #100 