### PR TITLE
Update Gradle to version 2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,12 @@
 
 buildscript {
   repositories {
+    jcenter()
     mavenCentral()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.3'
+    classpath 'com.android.tools.build:gradle:2.2.0'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
   }
 }

--- a/lost-sample/build.gradle
+++ b/lost-sample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.3'
+    classpath 'com.android.tools.build:gradle:2.2.0'
   }
 }
 

--- a/lost/build.gradle
+++ b/lost/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.3'
+    classpath 'com.android.tools.build:gradle:2.2.0'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
   }
 }


### PR DESCRIPTION
### Overview

Update Gradle script to version 2.2.0

### Proposed Changes

Modifies Gradle version in all `build.gradle` files and adds `jcenter()` repo to root build script.