### PR TITLE
116 dwell transition

### DIFF
--- a/lost-sample/src/main/java/com/example/lost/GeofencingApiActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/GeofencingApiActivity.java
@@ -11,6 +11,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
+import static com.mapzen.android.lost.api.Geofence.GEOFENCE_TRANSITION_DWELL;
 import static com.mapzen.android.lost.api.Geofence.GEOFENCE_TRANSITION_ENTER;
 import static com.mapzen.android.lost.api.Geofence.GEOFENCE_TRANSITION_EXIT;
 import static com.mapzen.android.lost.api.Geofence.NEVER_EXPIRE;
@@ -84,7 +85,9 @@ public class GeofencingApiActivity extends LostApiClientActivity {
     Geofence geofence = new Geofence.Builder()
         .setRequestId(requestId)
         .setCircularRegion(latitude, longitude, radius)
-        .setTransitionTypes(GEOFENCE_TRANSITION_ENTER | GEOFENCE_TRANSITION_EXIT)
+        .setTransitionTypes(GEOFENCE_TRANSITION_ENTER | GEOFENCE_TRANSITION_EXIT |
+            GEOFENCE_TRANSITION_DWELL)
+        .setLoiteringDelay(10000)
         .setExpirationDuration(NEVER_EXPIRE)
         .build();
     GeofencingRequest request = new GeofencingRequest.Builder()

--- a/lost/src/main/AndroidManifest.xml
+++ b/lost/src/main/AndroidManifest.xml
@@ -22,7 +22,9 @@
         <action android:name="com.mapzen.lost.action.ACTION_GEOFENCING_SERVICE"/>
       </intent-filter>
     </service>
+    <service android:name="com.mapzen.android.lost.internal.DwellIntentService">
 
+    </service>
   </application>
 
 </manifest>

--- a/lost/src/main/java/com/mapzen/android/lost/api/Geofence.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/Geofence.java
@@ -25,6 +25,7 @@ public interface Geofence {
     private float radius;
     private long durationMillis = NEVER_EXPIRE;
     private int transitionTypes;
+    private int loiteringDelayMs;
 
     /**
      * Construct and return a new {@link Geofence} object from the {@link Builder}'s properties.
@@ -32,7 +33,7 @@ public interface Geofence {
      */
     public Geofence build() {
       return new ParcelableGeofence(requestId, latitude, longitude, radius, durationMillis,
-          transitionTypes);
+          transitionTypes, loiteringDelayMs);
     }
 
     /**
@@ -60,10 +61,14 @@ public interface Geofence {
     }
 
     /**
-     * Not yet implemented
+     * Sets the loitering delay in millis for the {@link Builder}. If transition type is set to
+     * dwell then this value is used, otherwise it is ignored.
+     * @param loiteringDelayMs duration in milliseconds.
+     * @return the {@link Builder} object.
      */
     public Geofence.Builder setLoiteringDelay(int loiteringDelayMs) {
-      throw new RuntimeException("Sorry, not yet implemented");
+      this.loiteringDelayMs = loiteringDelayMs;
+      return this;
     }
 
     /**

--- a/lost/src/main/java/com/mapzen/android/lost/api/Geofence.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/Geofence.java
@@ -12,6 +12,7 @@ public interface Geofence {
   int GEOFENCE_TRANSITION_EXIT = 2;
   int GEOFENCE_TRANSITION_DWELL = 4;
   long NEVER_EXPIRE = -1L;
+  int LOITERING_DELAY_NONE = -1;
 
   String getRequestId();
 
@@ -25,7 +26,7 @@ public interface Geofence {
     private float radius;
     private long durationMillis = NEVER_EXPIRE;
     private int transitionTypes;
-    private int loiteringDelayMs;
+    private int loiteringDelayMs = LOITERING_DELAY_NONE;
 
     /**
      * Construct and return a new {@link Geofence} object from the {@link Builder}'s properties.

--- a/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentSender.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/GeofencingIntentSender.java
@@ -1,6 +1,7 @@
 package com.mapzen.android.lost.api;
 
 import com.mapzen.android.lost.internal.FusionEngine;
+import com.mapzen.android.lost.internal.GeofenceIntentHelper;
 import com.mapzen.android.lost.internal.GeofencingApiImpl;
 import com.mapzen.android.lost.internal.ParcelableGeofence;
 
@@ -8,10 +9,8 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
-import android.os.Bundle;
 
 import java.util.ArrayList;
-import java.util.Set;
 
 /**
  * Handles generating an intent populated with relevant extras from an {@link Intent} fired by
@@ -20,16 +19,16 @@ import java.util.Set;
  */
 public class GeofencingIntentSender {
 
-  public static final String EXTRA_ENTERING = "entering";
-
   private Context context;
   private FusionEngine engine;
   private GeofencingApiImpl geofencingApi;
+  private GeofenceIntentHelper intentHelper;
 
   public GeofencingIntentSender(Context context, GeofencingApi geofencingApi) {
     this.context = context;
     this.geofencingApi = (GeofencingApiImpl) geofencingApi;
     engine = new FusionEngine(context, null);
+    intentHelper = new GeofenceIntentHelper();
   }
 
   public void sendIntent(Intent intent) {
@@ -39,7 +38,7 @@ public class GeofencingIntentSender {
 
     Intent toSend = generateIntent(intent, engine.getLastLocation());
 
-    int intentId = extractIntentId(intent);
+    int intentId = intentHelper.extractIntentId(intent);
     PendingIntent pendingIntent = geofencingApi.pendingIntentForIntentId(intentId);
     try {
       pendingIntent.send(context, 0, toSend);
@@ -49,43 +48,22 @@ public class GeofencingIntentSender {
   }
 
   public boolean shouldSendIntent(Intent intent) {
-    int transition = transitionForIntent(intent);
-    int intentId = extractIntentId(intent);
+    int transition = intentHelper.transitionForIntent(intent);
+    int intentId = intentHelper.extractIntentId(intent);
     ParcelableGeofence geofence = (ParcelableGeofence) geofencingApi.geofenceForIntentId(intentId);
     return (geofence.getTransitionTypes() & transition) != 0;
   }
 
   public Intent generateIntent(Intent intent, Location location) {
-    int intentId = extractIntentId(intent);
+    int intentId = intentHelper.extractIntentId(intent);
     Geofence geofence = geofencingApi.geofenceForIntentId(intentId);
     ArrayList<Geofence> geofences = new ArrayList<>();
     geofences.add(geofence);
 
     Intent toSend = new Intent();
-    toSend.putExtra(GeofencingApi.EXTRA_TRANSITION, transitionForIntent(intent));
+    toSend.putExtra(GeofencingApi.EXTRA_TRANSITION, intentHelper.transitionForIntent(intent));
     toSend.putExtra(GeofencingApi.EXTRA_GEOFENCE_LIST, geofences);
     toSend.putExtra(GeofencingApi.EXTRA_TRIGGERING_LOCATION, location);
     return toSend;
-  }
-
-  private int transitionForIntent(Intent intent) {
-    Bundle extras = intent.getExtras();
-    int transition;
-    if (extras.containsKey(EXTRA_ENTERING)) {
-      if (extras.getBoolean(EXTRA_ENTERING)) {
-        transition = Geofence.GEOFENCE_TRANSITION_ENTER;
-      } else {
-        transition = Geofence.GEOFENCE_TRANSITION_EXIT;
-      }
-    } else {
-      transition = Geofence.GEOFENCE_TRANSITION_DWELL;
-    }
-    return transition;
-  }
-
-  private int extractIntentId(Intent intent) {
-    Set<String> categories = intent.getCategories();
-    String intentStr = categories.iterator().next();
-    return Integer.valueOf(intentStr);
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationServices.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationServices.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.lost.api;
 
+import com.mapzen.android.lost.internal.DwellServiceIntentFactory;
 import com.mapzen.android.lost.internal.FusedLocationProviderApiImpl;
 import com.mapzen.android.lost.internal.GeofencingApiImpl;
 import com.mapzen.android.lost.internal.GeofencingServiceIntentFactory;
@@ -21,7 +22,8 @@ public class LocationServices {
    * Entry point for APIs concerning geofences.
    */
   public static final GeofencingApi GeofencingApi = new GeofencingApiImpl(
-      new GeofencingServiceIntentFactory(), new PendingIntentIdGenerator());
+      new GeofencingServiceIntentFactory(), new DwellServiceIntentFactory(),
+      new PendingIntentIdGenerator());
 
   /**
    * Entry point for APIs concerning location settings.

--- a/lost/src/main/java/com/mapzen/android/lost/internal/DwellIntentService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/DwellIntentService.java
@@ -1,0 +1,24 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.GeofencingIntentSender;
+import com.mapzen.android.lost.api.LocationServices;
+
+import android.app.IntentService;
+import android.content.Intent;
+
+/**
+ * Service in charge of handling intents fired after a user has entered a geofence and remained
+ * inside of it for a given loitering delay.
+ */
+public class DwellIntentService extends IntentService {
+
+  public DwellIntentService() {
+    super("DwellIntentService");
+  }
+
+  @Override protected void onHandleIntent(Intent intent) {
+    GeofencingIntentSender intentSender = new GeofencingIntentSender(this,
+        LocationServices.GeofencingApi);
+    intentSender.sendIntent(intent);
+  }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/internal/DwellServiceIntentFactory.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/DwellServiceIntentFactory.java
@@ -16,6 +16,6 @@ public class DwellServiceIntentFactory implements IntentFactory {
 
   @Override
   public PendingIntent createPendingIntent(Context context, int pendingIntentId, Intent intent) {
-    return PendingIntent.getService(context, 0, intent, 0);
+    return PendingIntent.getService(context, pendingIntentId, intent, 0);
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/DwellServiceIntentFactory.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/DwellServiceIntentFactory.java
@@ -1,0 +1,21 @@
+package com.mapzen.android.lost.internal;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Class to handle creating {@link Intent} and {@link PendingIntent} objects to be sent to
+ * {@link DwellIntentService}
+ */
+public class DwellServiceIntentFactory implements IntentFactory {
+
+  @Override public Intent createIntent(Context context) {
+    return new Intent(context, DwellIntentService.class);
+  }
+
+  @Override
+  public PendingIntent createPendingIntent(Context context, int pendingIntentId, Intent intent) {
+    return PendingIntent.getService(context, 0, intent, 0);
+  }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/internal/GeofenceIntentHelper.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/GeofenceIntentHelper.java
@@ -1,0 +1,37 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.Geofence;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import java.util.Set;
+
+/**
+ * Helper class for extracting {@link Geofence} information from an {@link Intent}.
+ */
+public class GeofenceIntentHelper {
+
+  public static final String EXTRA_ENTERING = "entering";
+
+  public int transitionForIntent(Intent intent) {
+    Bundle extras = intent.getExtras();
+    int transition;
+    if (extras.containsKey(EXTRA_ENTERING)) {
+      if (extras.getBoolean(EXTRA_ENTERING)) {
+        transition = Geofence.GEOFENCE_TRANSITION_ENTER;
+      } else {
+        transition = Geofence.GEOFENCE_TRANSITION_EXIT;
+      }
+    } else {
+      transition = Geofence.GEOFENCE_TRANSITION_DWELL;
+    }
+    return transition;
+  }
+
+  public int extractIntentId(Intent intent) {
+    Set<String> categories = intent.getCategories();
+    String intentStr = categories.iterator().next();
+    return Integer.valueOf(intentStr);
+  }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
+import static android.app.AlarmManager.RTC_WAKEUP;
 import static com.mapzen.android.lost.api.Geofence.LOITERING_DELAY_NONE;
 
 /**
@@ -158,7 +159,7 @@ public class GeofencingApiImpl implements GeofencingApi {
     intent.addCategory(String.valueOf(pendingIntentId));
     PendingIntent pendingIntent = dwellServiceIntentFactory.createPendingIntent(context,
         pendingIntentId, intent);
-    alarmManager.set(1, System.currentTimeMillis() + loiterDelay, pendingIntent);
+    alarmManager.set(RTC_WAKEUP, System.currentTimeMillis() + loiterDelay, pendingIntent);
 
     enteredFences.put(geofence, pendingIntent);
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingDwellManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingDwellManager.java
@@ -1,0 +1,36 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.Geofence;
+import com.mapzen.android.lost.api.GeofencingApi;
+
+import android.content.Intent;
+
+/**
+ * Handles updating the {@link GeofencingApi}'s knowledge about which {@link Geofence} objects
+ * the user has entered/exited so that the dwell transition can be properly dispatched.
+ */
+public class GeofencingDwellManager {
+
+  GeofencingApiImpl geofencingApi;
+  GeofenceIntentHelper intentHelper;
+
+  public GeofencingDwellManager(GeofencingApi geofencingApi) {
+    this.geofencingApi = (GeofencingApiImpl) geofencingApi;
+    intentHelper = new GeofenceIntentHelper();
+  }
+
+  public void handleIntent(Intent intent) {
+    int transition = intentHelper.transitionForIntent(intent);
+    int intentId = intentHelper.extractIntentId(intent);
+    ParcelableGeofence geofence = (ParcelableGeofence) geofencingApi.geofenceForIntentId(intentId);
+    switch (transition) {
+      case Geofence.GEOFENCE_TRANSITION_ENTER:
+        geofencingApi.geofenceEntered(geofence, intentId);
+        break;
+      case Geofence.GEOFENCE_TRANSITION_EXIT:
+        geofencingApi.geofenceExited(geofence);
+      default:
+        break;
+    }
+  }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingIntentService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingIntentService.java
@@ -23,6 +23,10 @@ public class GeofencingIntentService extends IntentService {
     GeofencingIntentSender intentGenerator = new GeofencingIntentSender(this,
         LocationServices.GeofencingApi);
     intentGenerator.sendIntent(intent);
+
+    GeofencingDwellManager dwellManager = new GeofencingDwellManager(
+        LocationServices.GeofencingApi);
+    dwellManager.handleIntent(intent);
   }
 
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/ParcelableGeofence.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/ParcelableGeofence.java
@@ -13,9 +13,10 @@ public class ParcelableGeofence implements Geofence, Parcelable {
   private float radius;
   private long durationMillis = NEVER_EXPIRE;
   private int transitionTypes;
+  private int loiteringDelayMs;
 
   public ParcelableGeofence(String requestId, double latitude, double longitude, float radius,
-      long durationMillis, int transitionTypes) {
+      long durationMillis, int transitionTypes, int loiteringDelayMs) {
     this.requestId = requestId;
     this.latitude = latitude;
     this.longitude = longitude;
@@ -27,6 +28,7 @@ public class ParcelableGeofence implements Geofence, Parcelable {
       this.durationMillis = durationMillis;
     }
     this.transitionTypes = transitionTypes;
+    this.loiteringDelayMs = loiteringDelayMs;
   }
 
   @Override public String getRequestId() {
@@ -51,6 +53,10 @@ public class ParcelableGeofence implements Geofence, Parcelable {
 
   public int getTransitionTypes() {
     return transitionTypes;
+  }
+
+  public int getLoiteringDelayMs() {
+    return loiteringDelayMs;
   }
 
   // Parcelable

--- a/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
@@ -276,4 +276,17 @@ public class GeofencingApiTest {
     verify(alarmManager).cancel(any(PendingIntent.class));
   }
 
+
+  @Test(expected = IllegalStateException.class)
+  public void requestGeofence_shouldThrowExceptionForMissingLoitering() {
+    Geofence geofence = new Geofence.Builder()
+        .setRequestId("test_id")
+        .setCircularRegion(1, 2, 3)
+        .setExpirationDuration(NEVER_EXPIRE)
+        .setTransitionTypes(GEOFENCE_TRANSITION_DWELL)
+        .build();
+    GeofencingRequest request = new GeofencingRequest.Builder().addGeofence(geofence).build();
+    PendingIntent intent = Mockito.mock(PendingIntent.class);
+    geofencingApi.addGeofences(client, request, intent);
+  }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingApiTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.location.LocationManager;
@@ -19,10 +20,14 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static android.content.Context.LOCATION_SERVICE;
+import static com.mapzen.android.lost.api.Geofence.GEOFENCE_TRANSITION_DWELL;
 import static com.mapzen.android.lost.api.Geofence.NEVER_EXPIRE;
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("MissingPermission")
@@ -31,14 +36,20 @@ public class GeofencingApiTest {
   LocationManager locationManager;
   GeofencingApiImpl geofencingApi;
   LostApiClient client;
-  IntentFactory intentFactory;
+  IntentFactory geofencingIntentFactory;
+  IntentFactory dwellIntentFactory;
+  AlarmManager alarmManager;
 
   @Before public void setUp() throws Exception {
     context = mock(Context.class);
     locationManager = mock(LocationManager.class);
     when(context.getSystemService(LOCATION_SERVICE)).thenReturn(locationManager);
-    intentFactory = new TestIntentFactory();
-    geofencingApi = new GeofencingApiImpl(intentFactory, new PendingIntentIdGenerator());
+    alarmManager = mock(AlarmManager.class);
+    when(context.getSystemService(Context.ALARM_SERVICE)).thenReturn(alarmManager);
+    geofencingIntentFactory = new TestIntentFactory();
+    dwellIntentFactory = new TestIntentFactory();
+    geofencingApi = new GeofencingApiImpl(geofencingIntentFactory, dwellIntentFactory,
+        new PendingIntentIdGenerator());
     geofencingApi.connect(context);
     client = new LostApiClient.Builder(context).build();
   }
@@ -55,7 +66,7 @@ public class GeofencingApiTest {
     GeofencingRequest request = new GeofencingRequest.Builder().addGeofence(geofence).build();
     PendingIntent intent = Mockito.mock(PendingIntent.class);
     geofencingApi.addGeofences(client, request, intent);
-    PendingIntent pendingIntent = intentFactory.createPendingIntent(context, 123, null);
+    PendingIntent pendingIntent = geofencingIntentFactory.createPendingIntent(context, 123, null);
     Mockito.verify(locationManager, times(1)).addProximityAlert(1, 2, 3, NEVER_EXPIRE,
         pendingIntent);
   }
@@ -77,7 +88,7 @@ public class GeofencingApiTest {
     geofences.add(anotherGeofence);
     PendingIntent intent = Mockito.mock(PendingIntent.class);
     geofencingApi.addGeofences(client, geofences, intent);
-    PendingIntent pendingIntent = intentFactory.createPendingIntent(context, 123, null);
+    PendingIntent pendingIntent = geofencingIntentFactory.createPendingIntent(context, 123, null);
     Mockito.verify(locationManager, times(1)).addProximityAlert(1, 2, 3, NEVER_EXPIRE,
         pendingIntent);
     Mockito.verify(locationManager, times(1)).addProximityAlert(4, 5, 6, NEVER_EXPIRE,
@@ -236,6 +247,33 @@ public class GeofencingApiTest {
     TestResultCallback otherCallback = new TestResultCallback();
     result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
     assertThat(otherCallback.getStatus()).isNull();
+  }
+
+  @Test public void enterGeofence_shouldScheduleDwellPendingIntent() {
+    Geofence geofence = new Geofence.Builder()
+        .setRequestId("test_id")
+        .setCircularRegion(1, 2, 3)
+        .setExpirationDuration(NEVER_EXPIRE)
+        .setLoiteringDelay(1000)
+        .setTransitionTypes(GEOFENCE_TRANSITION_DWELL)
+        .build();
+    int pendingIntentId = 123;
+    geofencingApi.geofenceEntered(geofence, pendingIntentId);
+    verify(alarmManager).set(anyInt(), anyInt(), any(PendingIntent.class));
+  }
+
+  @Test public void exitGeofence_shouldCancelDwellPendingIntent() {
+    Geofence geofence = new Geofence.Builder()
+        .setRequestId("test_id")
+        .setCircularRegion(1, 2, 3)
+        .setExpirationDuration(NEVER_EXPIRE)
+        .setLoiteringDelay(1000)
+        .setTransitionTypes(GEOFENCE_TRANSITION_DWELL)
+        .build();
+    int pendingIntentId = 123;
+    geofencingApi.geofenceEntered(geofence, pendingIntentId);
+    geofencingApi.geofenceExited(geofence);
+    verify(alarmManager).cancel(any(PendingIntent.class));
   }
 
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingDwellManagerTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingDwellManagerTest.java
@@ -1,0 +1,56 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.Geofence;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import java.util.HashSet;
+
+import static com.mapzen.android.lost.internal.GeofenceIntentHelper.EXTRA_ENTERING;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by sarahlensing on 10/5/16.
+ */
+public class GeofencingDwellManagerTest {
+
+  GeofencingDwellManager dwellManager;
+  GeofencingApiImpl geofencingApi;
+
+  @Before public void setup() {
+    geofencingApi = mock(GeofencingApiImpl.class);
+    dwellManager = new GeofencingDwellManager(geofencingApi);
+  }
+
+  @Test public void handleIntent_shouldRegisterGeofenceEntered() {
+    Intent intent = mock(Intent.class);
+    when(intent.getExtras()).thenReturn(mock(Bundle.class));
+    when(intent.getExtras().containsKey(EXTRA_ENTERING)).thenReturn(true);
+    when(intent.getExtras().getBoolean(EXTRA_ENTERING)).thenReturn(true);
+    HashSet<String> categories = new HashSet<>();
+    categories.add("123");
+    when(intent.getCategories()).thenReturn(categories);
+    dwellManager.handleIntent(intent);
+    verify(geofencingApi).geofenceEntered(any(Geofence.class), anyInt());
+  }
+
+  @Test public void handleIntent_shouldRegisterGeofenceExited() {
+    Intent intent = mock(Intent.class);
+    when(intent.getExtras()).thenReturn(mock(Bundle.class));
+    when(intent.getExtras().containsKey(EXTRA_ENTERING)).thenReturn(true);
+    when(intent.getExtras().getBoolean(EXTRA_ENTERING)).thenReturn(false);
+    HashSet<String> categories = new HashSet<>();
+    categories.add("123");
+    when(intent.getCategories()).thenReturn(categories);
+    dwellManager.handleIntent(intent);
+    verify(geofencingApi).geofenceExited(any(Geofence.class));
+  }
+}

--- a/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingIntentSenderTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingIntentSenderTest.java
@@ -19,6 +19,7 @@ import android.os.Bundle;
 
 import java.util.ArrayList;
 
+import static com.mapzen.android.lost.internal.GeofenceIntentHelper.EXTRA_ENTERING;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -35,7 +36,8 @@ public class GeofencingIntentSenderTest {
 
   @Before public void setup() {
     IdGenerator idGenerator = new TestIdGenerator();
-    geofencingApi = new GeofencingApiImpl(new TestIntentFactory(), idGenerator);
+    geofencingApi = new GeofencingApiImpl(new TestIntentFactory(), new TestIntentFactory(),
+        idGenerator);
     intentSender = new GeofencingIntentSender(mock(Context.class), geofencingApi);
     context = mock(Context.class);
     when(context.getSystemService(Context.LOCATION_SERVICE)).thenReturn(
@@ -46,14 +48,14 @@ public class GeofencingIntentSenderTest {
   @Test public void generateIntent_shouldHaveExtras() {
     int intentId = geofenceId;
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_ENTER);
+        Geofence.GEOFENCE_TRANSITION_ENTER, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
 
     Intent intent = new Intent("");
     Bundle extras = new Bundle();
-    extras.putBoolean(GeofencingIntentSender.EXTRA_ENTERING, true);
+    extras.putBoolean(EXTRA_ENTERING, true);
     intent.putExtras(extras);
     intent.addCategory(String.valueOf(intentId));
 
@@ -72,12 +74,12 @@ public class GeofencingIntentSenderTest {
 
     Intent intent = new Intent("");
     Bundle extras = new Bundle();
-    extras.putBoolean(GeofencingIntentSender.EXTRA_ENTERING, true);
+    extras.putBoolean(EXTRA_ENTERING, true);
     intent.putExtras(extras);
     intent.addCategory(String.valueOf(intentId));
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_ENTER);
+        Geofence.GEOFENCE_TRANSITION_ENTER, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
@@ -91,12 +93,12 @@ public class GeofencingIntentSenderTest {
 
     Intent intent = new Intent("");
     Bundle extras = new Bundle();
-    extras.putBoolean(GeofencingIntentSender.EXTRA_ENTERING, true);
+    extras.putBoolean(EXTRA_ENTERING, true);
     intent.putExtras(extras);
     intent.addCategory(String.valueOf(intentId));
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_EXIT);
+        Geofence.GEOFENCE_TRANSITION_EXIT, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
@@ -110,12 +112,12 @@ public class GeofencingIntentSenderTest {
 
     Intent intent = new Intent("");
     Bundle extras = new Bundle();
-    extras.putBoolean(GeofencingIntentSender.EXTRA_ENTERING, true);
+    extras.putBoolean(EXTRA_ENTERING, true);
     intent.putExtras(extras);
     intent.addCategory(String.valueOf(intentId));
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_ENTER | Geofence.GEOFENCE_TRANSITION_EXIT);
+        Geofence.GEOFENCE_TRANSITION_ENTER | Geofence.GEOFENCE_TRANSITION_EXIT, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
@@ -129,12 +131,12 @@ public class GeofencingIntentSenderTest {
 
     Intent intent = new Intent("");
     Bundle extras = new Bundle();
-    extras.putBoolean(GeofencingIntentSender.EXTRA_ENTERING, true);
+    extras.putBoolean(EXTRA_ENTERING, true);
     intent.putExtras(extras);
     intent.addCategory(String.valueOf(intentId));
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_DWELL);
+        Geofence.GEOFENCE_TRANSITION_DWELL, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
@@ -148,12 +150,12 @@ public class GeofencingIntentSenderTest {
 
     Intent intent = new Intent("");
     Bundle extras = new Bundle();
-    extras.putBoolean(GeofencingIntentSender.EXTRA_ENTERING, false);
+    extras.putBoolean(EXTRA_ENTERING, false);
     intent.putExtras(extras);
     intent.addCategory(String.valueOf(intentId));
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_ENTER);
+        Geofence.GEOFENCE_TRANSITION_ENTER, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
@@ -167,12 +169,12 @@ public class GeofencingIntentSenderTest {
 
     Intent intent = new Intent("");
     Bundle extras = new Bundle();
-    extras.putBoolean(GeofencingIntentSender.EXTRA_ENTERING, false);
+    extras.putBoolean(EXTRA_ENTERING, false);
     intent.putExtras(extras);
     intent.addCategory(String.valueOf(intentId));
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_EXIT);
+        Geofence.GEOFENCE_TRANSITION_EXIT, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
@@ -186,12 +188,12 @@ public class GeofencingIntentSenderTest {
 
     Intent intent = new Intent("");
     Bundle extras = new Bundle();
-    extras.putBoolean(GeofencingIntentSender.EXTRA_ENTERING, false);
+    extras.putBoolean(EXTRA_ENTERING, false);
     intent.putExtras(extras);
     intent.addCategory(String.valueOf(intentId));
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_ENTER | Geofence.GEOFENCE_TRANSITION_EXIT);
+        Geofence.GEOFENCE_TRANSITION_ENTER | Geofence.GEOFENCE_TRANSITION_EXIT, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
@@ -205,12 +207,12 @@ public class GeofencingIntentSenderTest {
 
     Intent intent = new Intent("");
     Bundle extras = new Bundle();
-    extras.putBoolean(GeofencingIntentSender.EXTRA_ENTERING, true);
+    extras.putBoolean(EXTRA_ENTERING, true);
     intent.putExtras(extras);
     intent.addCategory(String.valueOf(intentId));
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_DWELL);
+        Geofence.GEOFENCE_TRANSITION_DWELL, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
@@ -228,7 +230,7 @@ public class GeofencingIntentSenderTest {
     intent.addCategory(String.valueOf(intentId));
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_ENTER);
+        Geofence.GEOFENCE_TRANSITION_ENTER, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
@@ -246,7 +248,7 @@ public class GeofencingIntentSenderTest {
     intent.addCategory(String.valueOf(intentId));
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_EXIT);
+        Geofence.GEOFENCE_TRANSITION_EXIT, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
@@ -265,7 +267,7 @@ public class GeofencingIntentSenderTest {
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
         Geofence.GEOFENCE_TRANSITION_ENTER | Geofence.GEOFENCE_TRANSITION_EXIT
-            | Geofence.GEOFENCE_TRANSITION_DWELL);
+            | Geofence.GEOFENCE_TRANSITION_DWELL, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);
@@ -283,7 +285,7 @@ public class GeofencingIntentSenderTest {
     intent.addCategory(String.valueOf(intentId));
 
     ParcelableGeofence geofence = new ParcelableGeofence("test", 40.0, 70.0, 50.0f, 1000,
-        Geofence.GEOFENCE_TRANSITION_DWELL);
+        Geofence.GEOFENCE_TRANSITION_DWELL, 0);
     ArrayList<Geofence> allGeofences = new ArrayList<>();
     allGeofences.add(geofence);
     geofencingApi.addGeofences(null, allGeofences, null);

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestDwellIntentFactory.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestDwellIntentFactory.java
@@ -1,0 +1,19 @@
+package com.mapzen.android.lost.internal;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Created by sarahlensing on 10/5/16.
+ */
+public class TestDwellIntentFactory implements IntentFactory {
+  @Override public Intent createIntent(Context context) {
+    return null;
+  }
+
+  @Override
+  public PendingIntent createPendingIntent(Context context, int pendingIntentId, Intent intent) {
+    return null;
+  }
+}


### PR DESCRIPTION
### Overview
This PR adds support for setting a loitering delay on `Geofence` as well as dispatching dwell transition events.

### Proposed Changes
When a geofence is entered, an alarm is scheduled to fire after a delay determined by the value of the geofence's loitering delay. When the alarm fires, the dwell transition is sent in the `Intent` data. If a geofence is exited before this interval, then the alarm is cancelled and no dwell transition is fired.

Closes #116  