### PR TITLE
Install SDK dependencies one at a time

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,9 @@ machine:
 
 dependencies:
   pre:
-    - echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.2,android-24,extra-android-m2repository"
+    - echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.2"
+    - echo y | android update sdk --all --no-ui --force --filter "android-24"
+    - echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository"
 
 test:
   override:


### PR DESCRIPTION
### Overview

Separates installation of Android SDK dependencies on Circle CI.

### Proposed Changes

Fixes license error by accepting each license one at a time.

```
> You have not accepted the license agreements of the following SDK components:
  [Android Support Repository].
  Before building your project, you need to accept the license agreements and complete the installation of the missing components using the Android Studio SDK Manager.
```