### PR TITLE
Dont require bluetooth permission

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/LocationSettingsResultRequest.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LocationSettingsResultRequest.java
@@ -8,8 +8,10 @@ import com.mapzen.android.lost.api.PendingResult;
 import com.mapzen.android.lost.api.ResultCallback;
 import com.mapzen.android.lost.api.Status;
 
+import android.Manifest;
 import android.app.PendingIntent;
 import android.bluetooth.BluetoothAdapter;
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.location.LocationManager;
 import android.support.annotation.NonNull;
@@ -31,6 +33,7 @@ import static com.mapzen.android.lost.api.Status.TIMEOUT;
 
 public class LocationSettingsResultRequest extends PendingResult<LocationSettingsResult> {
 
+  private final Context context;
   private final BluetoothAdapter bluetoothAdapter;
   private final PackageManager packageManager;
   private final LocationManager locationManager;
@@ -40,8 +43,10 @@ public class LocationSettingsResultRequest extends PendingResult<LocationSetting
 
   Future<LocationSettingsResult> future;
 
-  public LocationSettingsResultRequest(BluetoothAdapter btAdapter, PackageManager pm,
-      LocationManager lm, PendingIntentGenerator generator, LocationSettingsRequest request) {
+  public LocationSettingsResultRequest(Context context, BluetoothAdapter btAdapter,
+      PackageManager pm, LocationManager lm, PendingIntentGenerator generator,
+      LocationSettingsRequest request) {
+    this.context = context;
     bluetoothAdapter = btAdapter;
     packageManager = pm;
     locationManager = lm;
@@ -109,7 +114,13 @@ public class LocationSettingsResultRequest extends PendingResult<LocationSetting
     boolean networkUsable = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
     boolean networkPresent =
         packageManager.hasSystemFeature(PackageManager.FEATURE_LOCATION_NETWORK);
-    boolean bleUsable = bluetoothAdapter != null && bluetoothAdapter.isEnabled();
+
+
+    String pkgName = context.getPackageName();
+    boolean hasBtPermission = packageManager.checkPermission(
+        Manifest.permission.BLUETOOTH, pkgName) == PackageManager.PERMISSION_GRANTED;
+    boolean bleUsable = hasBtPermission && bluetoothAdapter != null
+        && bluetoothAdapter.isEnabled();
     boolean blePresent = packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE);
 
     boolean hasGpsResolution = needGps && gpsPresent && !gpsUsable;

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LocationSettingsResultRequest.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LocationSettingsResultRequest.java
@@ -44,12 +44,11 @@ public class LocationSettingsResultRequest extends PendingResult<LocationSetting
   Future<LocationSettingsResult> future;
 
   public LocationSettingsResultRequest(Context context, BluetoothAdapter btAdapter,
-      PackageManager pm, LocationManager lm, PendingIntentGenerator generator,
-      LocationSettingsRequest request) {
+      PendingIntentGenerator generator, LocationSettingsRequest request) {
     this.context = context;
+    packageManager = context.getPackageManager();
+    locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
     bluetoothAdapter = btAdapter;
-    packageManager = pm;
-    locationManager = lm;
     pendingIntentGenerator = generator;
     settingsRequest = request;
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/SettingsApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/SettingsApiImpl.java
@@ -44,7 +44,7 @@ public class SettingsApiImpl implements SettingsApi {
     LocationManager locationManager =
         (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
     PendingIntentGenerator generator = new PendingIntentGenerator(context);
-    return new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
-        request);
+    return new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager,
+        generator, request);
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/SettingsApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/SettingsApiImpl.java
@@ -8,8 +8,6 @@ import com.mapzen.android.lost.api.SettingsApi;
 
 import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
-import android.content.pm.PackageManager;
-import android.location.LocationManager;
 
 public class SettingsApiImpl implements SettingsApi {
 
@@ -40,11 +38,7 @@ public class SettingsApiImpl implements SettingsApi {
   @Override
   public PendingResult<LocationSettingsResult> checkLocationSettings(LostApiClient client,
       LocationSettingsRequest request) {
-    PackageManager pm = context.getPackageManager();
-    LocationManager locationManager =
-        (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
     PendingIntentGenerator generator = new PendingIntentGenerator(context);
-    return new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager,
-        generator, request);
+    return new LocationSettingsResultRequest(context, bluetoothAdapter, generator, request);
   }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LocationSettingsResultRequestTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LocationSettingsResultRequestTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
         .build();
 
     resultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
             request);
   }
 
@@ -177,7 +177,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
             settingsRequest);
 
     LocationSettingsResult result = settingsResultRequest.await();
@@ -201,7 +201,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(true)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
             settingsRequest);
 
     LocationSettingsResult result = settingsResultRequest.await();
@@ -226,7 +226,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
             settingsRequest);
 
     LocationSettingsResult result = settingsResultRequest.await();
@@ -247,7 +247,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
             settingsRequest);
 
     LocationSettingsResult result = settingsResultRequest.await();
@@ -268,7 +268,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(true)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
             settingsRequest);
 
     LocationSettingsResult result = settingsResultRequest.await();
@@ -282,8 +282,8 @@ import static org.mockito.Mockito.when;
 
     DelayTestPendingIntentGenerator delayedGenerator = new DelayTestPendingIntentGenerator(context);
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, delayedGenerator,
-            request);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager,
+            delayedGenerator, request);
 
     LocationSettingsResult resultRequest = settingsResultRequest.await(1000, TimeUnit.MILLISECONDS);
     assertThat(resultRequest.getStatus().getStatusCode()).isEqualTo(Status.TIMEOUT);
@@ -433,7 +433,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
             settingsRequest);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
@@ -461,7 +461,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(true)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
             settingsRequest);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
@@ -489,7 +489,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
             settingsRequest);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
@@ -513,7 +513,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
             settingsRequest);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
@@ -537,7 +537,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(true)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, generator,
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
             settingsRequest);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
@@ -554,8 +554,8 @@ import static org.mockito.Mockito.when;
 
     DelayTestPendingIntentGenerator delayedGenerator = new DelayTestPendingIntentGenerator(context);
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(bluetoothAdapter, pm, locationManager, delayedGenerator,
-            request);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager,
+            delayedGenerator, request);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
       @Override public void onResult(@NonNull LocationSettingsResult result) {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LocationSettingsResultRequestTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LocationSettingsResultRequestTest.java
@@ -39,6 +39,9 @@ import static org.mockito.Mockito.when;
     locationManager = Mockito.mock(LocationManager.class);
     generator = new TestPendingIntentGenerator(context);
 
+    when(context.getPackageManager()).thenReturn(pm);
+    when(context.getSystemService(Context.LOCATION_SERVICE)).thenReturn(locationManager);
+
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest highAccuracy =
         LocationRequest.create().setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY); //gps + wifi
@@ -48,8 +51,7 @@ import static org.mockito.Mockito.when;
         .build();
 
     resultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
-            request);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, generator, request);
   }
 
   @Test public void await_shouldReturnSuccessfulResult() {
@@ -177,8 +179,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
-            settingsRequest);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, generator, settingsRequest);
 
     LocationSettingsResult result = settingsResultRequest.await();
     assertThat(result.getStatus().getStatusCode()).isEqualTo(Status.RESOLUTION_REQUIRED);
@@ -201,8 +202,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(true)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
-            settingsRequest);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, generator, settingsRequest);
 
     LocationSettingsResult result = settingsResultRequest.await();
     assertThat(result.getStatus().getStatusCode()).isEqualTo(Status.RESOLUTION_REQUIRED);
@@ -226,8 +226,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
-            settingsRequest);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, generator, settingsRequest);
 
     LocationSettingsResult result = settingsResultRequest.await();
     assertThat(result.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
@@ -247,8 +246,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
-            settingsRequest);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, generator, settingsRequest);
 
     LocationSettingsResult result = settingsResultRequest.await();
     assertThat(result.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
@@ -268,8 +266,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(true)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
-            settingsRequest);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, generator, settingsRequest);
 
     LocationSettingsResult result = settingsResultRequest.await();
     assertThat(result.getStatus().getStatusCode()).isEqualTo(Status.RESOLUTION_REQUIRED);
@@ -282,8 +279,7 @@ import static org.mockito.Mockito.when;
 
     DelayTestPendingIntentGenerator delayedGenerator = new DelayTestPendingIntentGenerator(context);
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager,
-            delayedGenerator, request);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, delayedGenerator, request);
 
     LocationSettingsResult resultRequest = settingsResultRequest.await(1000, TimeUnit.MILLISECONDS);
     assertThat(resultRequest.getStatus().getStatusCode()).isEqualTo(Status.TIMEOUT);
@@ -433,8 +429,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
-            settingsRequest);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, generator, settingsRequest);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
       @Override public void onResult(@NonNull LocationSettingsResult result) {
@@ -461,8 +456,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(true)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
-            settingsRequest);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, generator, settingsRequest);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
       @Override public void onResult(@NonNull LocationSettingsResult result) {
@@ -489,8 +483,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
-            settingsRequest);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, generator, settingsRequest);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
       @Override public void onResult(@NonNull LocationSettingsResult result) {
@@ -513,8 +506,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(false)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
-            settingsRequest);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, generator, settingsRequest);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
       @Override public void onResult(@NonNull LocationSettingsResult result) {
@@ -537,8 +529,7 @@ import static org.mockito.Mockito.when;
             .setNeedBle(true)
             .build();
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager, generator,
-            settingsRequest);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, generator, settingsRequest);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
       @Override public void onResult(@NonNull LocationSettingsResult result) {
@@ -554,8 +545,7 @@ import static org.mockito.Mockito.when;
 
     DelayTestPendingIntentGenerator delayedGenerator = new DelayTestPendingIntentGenerator(context);
     LocationSettingsResultRequest settingsResultRequest =
-        new LocationSettingsResultRequest(context, bluetoothAdapter, pm, locationManager,
-            delayedGenerator, request);
+        new LocationSettingsResultRequest(context, bluetoothAdapter, delayedGenerator, request);
 
     settingsResultRequest.setResultCallback(new ResultCallback<LocationSettingsResult>() {
       @Override public void onResult(@NonNull LocationSettingsResult result) {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/SettingsApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/SettingsApiImplTest.java
@@ -7,12 +7,17 @@ import com.mapzen.android.lost.api.PendingResult;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
+import android.Manifest;
 import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.location.LocationManager;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SettingsApiImplTest {
 
@@ -20,8 +25,8 @@ public class SettingsApiImplTest {
   SettingsApiImpl settingsApi;
 
   @Before public void setup() {
-    context = Mockito.mock(Context.class);
-    BluetoothAdapter adapter = Mockito.mock(BluetoothAdapter.class);
+    context = mock(Context.class);
+    BluetoothAdapter adapter = mock(BluetoothAdapter.class);
     settingsApi = new SettingsApiImpl(context, adapter);
   }
 
@@ -32,5 +37,21 @@ public class SettingsApiImplTest {
     PendingResult<LocationSettingsResult> result =
         settingsApi.checkLocationSettings(apiClient, request);
     assertThat(result).isInstanceOf(LocationSettingsResultRequest.class);
+  }
+
+  @Test public void checkLocationSettings_shouldNotRequireBluetoothPermission() {
+    PackageManager packageManager = mock(PackageManager.class);
+    String pkgName = "com.test.pkg";
+    LocationManager locationManager = mock(LocationManager.class);
+    when(context.getPackageName()).thenReturn(pkgName);
+    when(context.getPackageManager()).thenReturn(packageManager);
+    when(context.getSystemService(Context.LOCATION_SERVICE)).thenReturn(locationManager);
+
+    LocationSettingsRequest request = new LocationSettingsRequest.Builder().build();
+    LostApiClient apiClient = new LostApiClient.Builder(context).build();
+    PendingResult<LocationSettingsResult> result =
+        settingsApi.checkLocationSettings(apiClient, request);
+    result.await();
+    verify(packageManager).checkPermission(Manifest.permission.BLUETOOTH, pkgName);
   }
 }


### PR DESCRIPTION
### Overview
Don't require bluetooth permission when using the `SettingsApi`

### Proposed Changes
Check that the bluetooth permission is granted before calling `bluetoothAdapter.isEnabled()`

Closes #121 

