### PR TITLE
Fix connection state

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationServices.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationServices.java
@@ -2,6 +2,7 @@ package com.mapzen.android.lost.api;
 
 import com.mapzen.android.lost.internal.DwellServiceIntentFactory;
 import com.mapzen.android.lost.internal.FusedLocationProviderApiImpl;
+import com.mapzen.android.lost.internal.FusedLocationServiceConnectionManager;
 import com.mapzen.android.lost.internal.GeofencingApiImpl;
 import com.mapzen.android.lost.internal.GeofencingServiceIntentFactory;
 import com.mapzen.android.lost.internal.PendingIntentIdGenerator;
@@ -16,7 +17,7 @@ public class LocationServices {
    * Entry point for APIs concerning location updates.
    */
   public static final FusedLocationProviderApi FusedLocationApi =
-      new FusedLocationProviderApiImpl();
+      new FusedLocationProviderApiImpl(new FusedLocationServiceConnectionManager());
 
   /**
    * Entry point for APIs concerning geofences.

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -34,7 +34,7 @@ public class FusedLocationProviderApiImpl
 
   private Context context;
   private FusedLocationProviderService service;
-  private enum ConnectState { IDLE, CONNECTING, CONNECTED };
+  private enum ConnectState { IDLE, CONNECTING, CONNECTED }
   private ConnectState connectState;
 
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -52,17 +52,14 @@ public class FusedLocationProviderApiImpl
       }
     }
 
-    @Override public void onDisconnect(LostApiClient client, boolean stopService,
-        boolean disconnectService) {
+    @Override public void onDisconnect(LostApiClient client, boolean disconnectService) {
       if (disconnectService) {
         service.disconnect(client);
       }
-      if (stopService) {
-        context.unbindService(serviceConnection);
-        Intent intent = new Intent(context, FusedLocationProviderService.class);
-        context.stopService(intent);
-        service = null;
-      }
+      context.unbindService(serviceConnection);
+      Intent intent = new Intent(context, FusedLocationProviderService.class);
+      context.stopService(intent);
+      service = null;
     }
   };
 
@@ -93,12 +90,8 @@ public class FusedLocationProviderApiImpl
     serviceConnectionManager.connect(context, callbacks);
   }
 
-  public void disconnect() {
-    disconnect(null, true);
-  }
-
-  public void disconnect(LostApiClient client, boolean stopService) {
-    serviceConnectionManager.disconnect(client, stopService);
+  public void disconnect(LostApiClient client) {
+    serviceConnectionManager.disconnect(client);
   }
 
   public boolean isConnected() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -47,12 +47,12 @@ public class FusedLocationProviderApiImpl
           service = fusedBinder.getService();
         }
 
+        connectState = ConnectState.CONNECTED;
         if (!connectionCallbacks.isEmpty()) {
           for (LostApiClient.ConnectionCallbacks callbacks : connectionCallbacks) {
             callbacks.onConnected();
           }
         }
-        connectState = ConnectState.CONNECTED;
       }
       Log.d(TAG, "[onServiceConnected]");
     }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -1,5 +1,14 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.api.FusedLocationProviderApi;
+import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationCallback;
+import com.mapzen.android.lost.api.LocationListener;
+import com.mapzen.android.lost.api.LocationRequest;
+import com.mapzen.android.lost.api.LostApiClient;
+import com.mapzen.android.lost.api.PendingResult;
+import com.mapzen.android.lost.api.Status;
+
 import android.app.PendingIntent;
 import android.content.ComponentName;
 import android.content.Context;
@@ -10,17 +19,7 @@ import android.os.IBinder;
 import android.os.Looper;
 import android.util.Log;
 
-import com.mapzen.android.lost.api.FusedLocationProviderApi;
-import com.mapzen.android.lost.api.LocationAvailability;
-import com.mapzen.android.lost.api.LocationCallback;
-import com.mapzen.android.lost.api.LocationListener;
-import com.mapzen.android.lost.api.LocationRequest;
-import com.mapzen.android.lost.api.LostApiClient;
-import com.mapzen.android.lost.api.PendingResult;
-import com.mapzen.android.lost.api.Status;
-
 import java.io.File;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,62 +29,14 @@ import java.util.Set;
 public class FusedLocationProviderApiImpl
     implements FusedLocationProviderApi {
 
-  private static final String TAG = FusedLocationProviderApiImpl.class.getSimpleName();
-
   private Context context;
   private FusedLocationProviderService service;
-  private enum ConnectState { IDLE, CONNECTING, CONNECTED }
-  private ConnectState connectState;
+  private FusedLocationServiceConnectionManager serviceConnectionManager;
 
-
-  private final ServiceConnection serviceConnection = new ServiceConnection() {
-    @Override public void onServiceConnected(ComponentName name, IBinder binder) {
-      FusedLocationProviderService.FusedLocationProviderBinder fusedBinder =
-          (FusedLocationProviderService.FusedLocationProviderBinder) binder;
-      if (connectState != ConnectState.IDLE) {
-        if (fusedBinder != null) {
-          service = fusedBinder.getService();
-        }
-
-        connectState = ConnectState.CONNECTED;
-        if (!connectionCallbacks.isEmpty()) {
-          for (LostApiClient.ConnectionCallbacks callbacks : connectionCallbacks) {
-            callbacks.onConnected();
-          }
-        }
-      }
-      Log.d(TAG, "[onServiceConnected]");
-    }
-
-    @Override public void onServiceDisconnected(ComponentName name) {
-      if (connectState != ConnectState.IDLE) {
-        if (!connectionCallbacks.isEmpty()) {
-          for (LostApiClient.ConnectionCallbacks callbacks : connectionCallbacks) {
-            callbacks.onConnectionSuspended();
-          }
-        }
-        connectState = ConnectState.IDLE;
-      }
-      Log.d(TAG, "[onServiceDisconnected]");
-    }
-  };
-
-  Set<LostApiClient.ConnectionCallbacks> connectionCallbacks;
-
-
-  public boolean isConnecting() {
-    return connectState == ConnectState.CONNECTING;
-  }
-
-  public FusedLocationProviderApiImpl() {
-    connectionCallbacks = new HashSet<>();
-    connectState = ConnectState.IDLE;
-  }
-
-  public void connect(Context context, LostApiClient.ConnectionCallbacks callbacks) {
-    if (connectState == ConnectState.IDLE) {
-      this.context = context;
-      connectState = ConnectState.CONNECTING;
+  private FusedLocationServiceConnectionManager.EventCallbacks eventCallbacks =
+      new FusedLocationServiceConnectionManager.EventCallbacks() {
+    @Override public void onConnect(Context context) {
+      FusedLocationProviderApiImpl.this.context = context;
 
       Intent intent = new Intent(context, FusedLocationProviderService.class);
       context.startService(intent);
@@ -93,21 +44,20 @@ public class FusedLocationProviderApiImpl
       intent = new Intent(context, FusedLocationProviderService.class);
       context.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE);
     }
-    if (callbacks != null) {
-      connectionCallbacks.add(callbacks);
+
+    @Override public void onServiceConnected(IBinder binder) {
+      FusedLocationProviderService.FusedLocationProviderBinder fusedBinder =
+          (FusedLocationProviderService.FusedLocationProviderBinder) binder;
+      if (fusedBinder != null) {
+        service = fusedBinder.getService();
+      }
     }
-  }
 
-  public void disconnect() {
-    disconnect(null, true);
-  }
-
-  public void disconnect(LostApiClient client, boolean stopService) {
-    if (connectState != ConnectState.IDLE) {
-      if (connectState == ConnectState.CONNECTED) {
+    @Override public void onDisconnect(LostApiClient client, boolean stopService,
+        boolean disconnectService) {
+      if (disconnectService) {
         service.disconnect(client);
       }
-      connectState = ConnectState.IDLE;
       if (stopService) {
         context.unbindService(serviceConnection);
         Intent intent = new Intent(context, FusedLocationProviderService.class);
@@ -115,10 +65,44 @@ public class FusedLocationProviderApiImpl
         service = null;
       }
     }
+  };
+
+  private final ServiceConnection serviceConnection = new ServiceConnection() {
+    @Override public void onServiceConnected(ComponentName name, IBinder binder) {
+      serviceConnectionManager.onServiceConnected(binder);
+    }
+
+    @Override public void onServiceDisconnected(ComponentName name) {
+      serviceConnectionManager.onServiceDisconnected();
+    }
+  };
+
+  public FusedLocationProviderApiImpl() {
+    serviceConnectionManager = new FusedLocationServiceConnectionManager(eventCallbacks);
+  }
+
+  public boolean isConnecting() {
+    return serviceConnectionManager.isConnecting();
+  }
+
+  public void addConnectionCallbacks(LostApiClient.ConnectionCallbacks callbacks) {
+    serviceConnectionManager.addCallbacks(callbacks);
+  }
+
+  public void connect(Context context, LostApiClient.ConnectionCallbacks callbacks) {
+    serviceConnectionManager.connect(context, callbacks);
+  }
+
+  public void disconnect() {
+    disconnect(null, true);
+  }
+
+  public void disconnect(LostApiClient client, boolean stopService) {
+    serviceConnectionManager.disconnect(client, stopService);
   }
 
   public boolean isConnected() {
-    return connectState == ConnectState.CONNECTED;
+    return serviceConnectionManager.isConnected();
   }
 
   @Override public Location getLastLocation(LostApiClient client) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -17,7 +17,6 @@ import android.content.ServiceConnection;
 import android.location.Location;
 import android.os.IBinder;
 import android.os.Looper;
-import android.util.Log;
 
 import java.io.File;
 import java.util.Map;

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -77,8 +77,9 @@ public class FusedLocationProviderApiImpl
     }
   };
 
-  public FusedLocationProviderApiImpl() {
-    serviceConnectionManager = new FusedLocationServiceConnectionManager(eventCallbacks);
+  public FusedLocationProviderApiImpl(FusedLocationServiceConnectionManager connectionManager) {
+    serviceConnectionManager = connectionManager;
+    serviceConnectionManager.setEventCallbacks(eventCallbacks);
   }
 
   public boolean isConnecting() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
@@ -14,7 +14,7 @@ public class FusedLocationServiceConnectionManager {
   public interface EventCallbacks {
     void onConnect(Context context);
     void onServiceConnected(IBinder binder);
-    void onDisconnect(LostApiClient client, boolean stopService, boolean disconnectService);
+    void onDisconnect(LostApiClient client, boolean disconnectService);
   }
 
   private enum ConnectState { IDLE, CONNECTING, CONNECTED }
@@ -57,12 +57,12 @@ public class FusedLocationServiceConnectionManager {
     addCallbacks(callbacks);
   }
 
-  public void disconnect(LostApiClient client, boolean stopService) {
+  public void disconnect(LostApiClient client) {
     if (connectState != ConnectState.IDLE) {
       boolean disconnectService = (connectState == ConnectState.CONNECTED);
       connectState = ConnectState.IDLE;
       if (eventCallbacks != null) {
-        eventCallbacks.onDisconnect(client, stopService, disconnectService);
+        eventCallbacks.onDisconnect(client, disconnectService);
       }
     }
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
@@ -69,10 +69,11 @@ public class FusedLocationServiceConnectionManager {
 
   public void onServiceConnected(IBinder binder) {
     if (connectState != ConnectState.IDLE) {
+      connectState = ConnectState.CONNECTED;
       if (eventCallbacks != null) {
         eventCallbacks.onServiceConnected(binder);
       }
-      connectState = ConnectState.CONNECTED;
+
       if (!connectionCallbacks.isEmpty()) {
         for (LostApiClient.ConnectionCallbacks callbacks : connectionCallbacks) {
           callbacks.onConnected();
@@ -83,12 +84,12 @@ public class FusedLocationServiceConnectionManager {
 
   public void onServiceDisconnected() {
     if (connectState != ConnectState.IDLE) {
+      connectState = ConnectState.IDLE;
       if (!connectionCallbacks.isEmpty()) {
         for (LostApiClient.ConnectionCallbacks callbacks : connectionCallbacks) {
           callbacks.onConnectionSuspended();
         }
       }
-      connectState = ConnectState.IDLE;
     }
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
@@ -1,0 +1,93 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LostApiClient;
+import com.mapzen.android.lost.api.LostApiClient.ConnectionCallbacks;
+
+import android.content.Context;
+import android.os.IBinder;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class FusedLocationServiceConnectionManager {
+
+  public interface EventCallbacks {
+    void onConnect(Context context);
+    void onServiceConnected(IBinder binder);
+    void onDisconnect(LostApiClient client, boolean stopService, boolean disconnectService);
+  }
+
+  private enum ConnectState { IDLE, CONNECTING, CONNECTED }
+
+  private EventCallbacks eventCallbacks;
+  private ConnectState connectState;
+  Set<ConnectionCallbacks> connectionCallbacks;
+
+
+
+  public FusedLocationServiceConnectionManager(EventCallbacks callbacks) {
+    eventCallbacks = callbacks;
+    connectionCallbacks = new HashSet<>();
+    connectState = ConnectState.IDLE;
+  }
+
+  public void addCallbacks(ConnectionCallbacks callbacks) {
+    if (callbacks != null) {
+      connectionCallbacks.add(callbacks);
+    }
+  }
+
+  public boolean isConnected() {
+    return connectState == ConnectState.CONNECTED;
+  }
+
+  public boolean isConnecting() {
+    return connectState == ConnectState.CONNECTING;
+  }
+
+  public void connect(Context context, ConnectionCallbacks callbacks) {
+    if (connectState == ConnectState.IDLE) {
+      connectState = ConnectState.CONNECTING;
+
+      if (eventCallbacks != null) {
+        eventCallbacks.onConnect(context);
+      }
+    }
+    addCallbacks(callbacks);
+  }
+
+  public void disconnect(LostApiClient client, boolean stopService) {
+    if (connectState != ConnectState.IDLE) {
+      boolean disconnectService = (connectState == ConnectState.CONNECTED);
+      connectState = ConnectState.IDLE;
+      if (eventCallbacks != null) {
+        eventCallbacks.onDisconnect(client, stopService, disconnectService);
+      }
+    }
+  }
+
+  public void onServiceConnected(IBinder binder) {
+    if (connectState != ConnectState.IDLE) {
+      if (eventCallbacks != null) {
+        eventCallbacks.onServiceConnected(binder);
+      }
+      connectState = ConnectState.CONNECTED;
+      if (!connectionCallbacks.isEmpty()) {
+        for (LostApiClient.ConnectionCallbacks callbacks : connectionCallbacks) {
+          callbacks.onConnected();
+        }
+      }
+    }
+  }
+
+  public void onServiceDisconnected() {
+    if (connectState != ConnectState.IDLE) {
+      if (!connectionCallbacks.isEmpty()) {
+        for (LostApiClient.ConnectionCallbacks callbacks : connectionCallbacks) {
+          callbacks.onConnectionSuspended();
+        }
+      }
+      connectState = ConnectState.IDLE;
+    }
+  }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
@@ -23,12 +23,13 @@ public class FusedLocationServiceConnectionManager {
   private ConnectState connectState;
   Set<ConnectionCallbacks> connectionCallbacks;
 
-
-
-  public FusedLocationServiceConnectionManager(EventCallbacks callbacks) {
-    eventCallbacks = callbacks;
+  public FusedLocationServiceConnectionManager() {
     connectionCallbacks = new HashSet<>();
     connectState = ConnectState.IDLE;
+  }
+
+  public void setEventCallbacks(EventCallbacks callbacks) {
+    eventCallbacks = callbacks;
   }
 
   public void addCallbacks(ConnectionCallbacks callbacks) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
@@ -34,7 +34,7 @@ public class LostApiClientImpl implements LostApiClient {
       }
     } else if (fusedApi.isConnecting()) {
       if (connectionCallbacks != null) {
-        fusedApi.connectionCallbacks.add(connectionCallbacks);
+        fusedApi.addConnectionCallbacks(connectionCallbacks);
       }
     } else {
       fusedApi.connect(context, connectionCallbacks);

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
@@ -50,7 +50,7 @@ public class LostApiClientImpl implements LostApiClient {
 
     getSettingsApiImpl().disconnect();
     getGeofencingImpl().disconnect();
-    getFusedLocationProviderApiImpl().disconnect();
+    getFusedLocationProviderApiImpl().disconnect(null);
   }
 
   @Override public boolean isConnected() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -182,16 +182,4 @@ public class FusedLocationProviderApiImplTest {
     api.getLocationListeners();
     verify(service).getLocationListeners();
   }
-
-  class TestConnectionCallbacks implements LostApiClient.ConnectionCallbacks {
-
-    @Override public void onConnected() {
-
-    }
-
-    @Override public void onConnectionSuspended() {
-
-    }
-  }
-
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -95,9 +95,8 @@ public class FusedLocationProviderApiImplTest {
 
   @Test public void disconnect_shouldCallConnectionManager() {
     LostApiClient client = mock(LostApiClient.class);
-    boolean stopService = true;
-    api.disconnect(client, stopService);
-    verify(connectionManager).disconnect(client, stopService);
+    api.disconnect(client);
+    verify(connectionManager).disconnect(client);
   }
 
   @Test public void isConnected_shouldCallConnectionManager() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManagerTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManagerTest.java
@@ -82,7 +82,7 @@ public class FusedLocationServiceConnectionManagerTest {
 
   @Test public void disconnect_shouldNotSetStateConnectingConnected() {
     connectionManager.connect(null, null);
-    connectionManager.disconnect(null, false);
+    connectionManager.disconnect(null);
     assertThat(connectionManager.isConnecting()).isFalse();
     assertThat(connectionManager.isConnected()).isFalse();
   }
@@ -91,7 +91,7 @@ public class FusedLocationServiceConnectionManagerTest {
     TestEventCallbacks callbacks = new TestEventCallbacks();
     connectionManager.setEventCallbacks(callbacks);
     connectionManager.connect(null, null);
-    connectionManager.disconnect(null, false);
+    connectionManager.disconnect(null);
     assertThat(callbacks.connected).isFalse();
   }
 
@@ -99,7 +99,7 @@ public class FusedLocationServiceConnectionManagerTest {
     TestEventCallbacks callbacks = new TestEventCallbacks();
     connectionManager.setEventCallbacks(callbacks);
     connectionManager.connect(null, null);
-    connectionManager.disconnect(null, false);
+    connectionManager.disconnect(null);
     assertThat(callbacks.idleOnDisconnect).isTrue();
   }
 
@@ -107,7 +107,7 @@ public class FusedLocationServiceConnectionManagerTest {
     TestEventCallbacks callbacks = new TestEventCallbacks();
     callbacks.onConnect(null);
     connectionManager.setEventCallbacks(callbacks);
-    connectionManager.disconnect(null, false);
+    connectionManager.disconnect(null);
     assertThat(callbacks.connected).isTrue();
   }
 
@@ -206,7 +206,7 @@ public class FusedLocationServiceConnectionManagerTest {
     }
 
     @Override
-    public void onDisconnect(LostApiClient client, boolean stopService, boolean disconnectService) {
+    public void onDisconnect(LostApiClient client, boolean disconnectService) {
       connected = false;
       idleOnDisconnect = !connectionManager.isConnected() && !connectionManager.isConnecting();
     }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManagerTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManagerTest.java
@@ -1,0 +1,174 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LostApiClient;
+
+import org.junit.Test;
+
+import android.content.Context;
+import android.os.IBinder;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class FusedLocationServiceConnectionManagerTest {
+
+  FusedLocationServiceConnectionManager connectionManager =
+      new FusedLocationServiceConnectionManager();
+
+  @Test public void shouldNotBeConnecting() {
+    assertThat(connectionManager.isConnecting()).isFalse();
+  }
+
+  @Test public void shouldNotBeConnected() {
+    assertThat(connectionManager.isConnected()).isFalse();
+  }
+
+  @Test public void setEventCallbacks_shouldSetCallbacks() {
+    TestEventCallbacks eventCallbacks = new TestEventCallbacks();
+    connectionManager.setEventCallbacks(eventCallbacks);
+    eventCallbacks.onConnect(null);
+    assertThat(eventCallbacks.connected).isTrue();
+  }
+
+  @Test public void addCallbacks_shouldAddCallbacks() {
+    TestConnectionCallbacks connectionCallbacks = new TestConnectionCallbacks();
+    connectionManager.addCallbacks(connectionCallbacks);
+    connectionCallbacks.onConnected();
+    assertThat(connectionCallbacks.isConnected()).isTrue();
+  }
+
+  @Test public void isConnected_shouldBeTrue() {
+    connectionManager.connect(null, null);
+    connectionManager.onServiceConnected(null);
+    assertThat(connectionManager.isConnected()).isTrue();
+  }
+
+  @Test public void isConnecting_shouldBeTrue() {
+    connectionManager.connect(null, null);
+    assertThat(connectionManager.isConnecting()).isTrue();
+  }
+
+  @Test public void connect_shouldCallEventCallbacks() {
+    TestEventCallbacks eventCallbacks = new TestEventCallbacks();
+    connectionManager.setEventCallbacks(eventCallbacks);
+    connectionManager.connect(null, null);
+    assertThat(eventCallbacks.connected).isTrue();
+  }
+
+  @Test public void connect_shouldAddConnectionCallbacks() {
+    TestConnectionCallbacks connectionCallbacks = new TestConnectionCallbacks();
+    connectionManager.connect(null, connectionCallbacks);
+    connectionManager.onServiceConnected(null);
+    assertThat(connectionCallbacks.isConnected()).isTrue();
+    connectionManager.onServiceDisconnected();
+    assertThat(connectionCallbacks.isConnected()).isFalse();
+  }
+
+  @Test public void connect_shouldNotCallEventCallbacks() {
+    connectionManager.connect(null, null);
+    TestEventCallbacks eventCallbacks = new TestEventCallbacks();
+    connectionManager.setEventCallbacks(eventCallbacks);
+    connectionManager.connect(null, null);
+    assertThat(eventCallbacks.connected).isFalse();
+  }
+
+  @Test public void disconnect_shouldNotSetStateConnectingConnected() {
+    connectionManager.connect(null, null);
+    connectionManager.disconnect(null, false);
+    assertThat(connectionManager.isConnecting()).isFalse();
+    assertThat(connectionManager.isConnected()).isFalse();
+  }
+
+  @Test public void disconnect_shouldCallEventCallback() {
+    TestEventCallbacks callbacks = new TestEventCallbacks();
+    connectionManager.setEventCallbacks(callbacks);
+    connectionManager.connect(null, null);
+    connectionManager.disconnect(null, false);
+    assertThat(callbacks.connected).isFalse();
+  }
+
+  @Test public void disconnect_shouldNotCallEventCallback() {
+    TestEventCallbacks callbacks = new TestEventCallbacks();
+    callbacks.onConnect(null);
+    connectionManager.setEventCallbacks(callbacks);
+    connectionManager.disconnect(null, false);
+    assertThat(callbacks.connected).isTrue();
+  }
+
+  @Test public void onServiceConnected_shouldCallEventCallbacks() {
+    TestEventCallbacks eventCallbacks = mock(TestEventCallbacks.class);
+    connectionManager.setEventCallbacks(eventCallbacks);
+    connectionManager.connect(null, null);
+    IBinder binder = mock(IBinder.class);
+    connectionManager.onServiceConnected(binder);
+    verify(eventCallbacks).onServiceConnected(binder);
+  }
+
+  @Test public void onServiceConnected_shouldSetConnectionStateConnected() {
+    connectionManager.connect(null, null);
+    connectionManager.onServiceConnected(null);
+    assertThat(connectionManager.isConnected()).isTrue();
+  }
+
+  @Test public void onServiceConnected_shouldCallConnectionCallbackAndBeConnected() {
+    TestConnectionCallbacks connectionCallbacks = new TestConnectionCallbacks();
+    connectionManager.connect(null, connectionCallbacks);
+    connectionManager.onServiceConnected(null);
+    assertThat(connectionCallbacks.isConnected()).isTrue();
+    assertThat(connectionManager.isConnected()).isTrue();
+  }
+
+  @Test public void onServiceConnected_shouldNotCallEventCallbacks() {
+    TestEventCallbacks eventCallbacks = mock(TestEventCallbacks.class);
+    connectionManager.setEventCallbacks(eventCallbacks);
+    connectionManager.onServiceConnected(null);
+    assertThat(eventCallbacks.serviceConnected).isFalse();
+  }
+
+  @Test public void onServiceConnected_shouldNotCallConnectionCallback() {
+    TestConnectionCallbacks connectionCallbacks = new TestConnectionCallbacks();
+    connectionManager.onServiceConnected(null);
+    assertThat(connectionCallbacks.isConnected()).isFalse();
+  }
+
+  @Test public void onServiceDisconnected_shouldCallConnectionCallback() {
+    TestConnectionCallbacks connectionCallbacks = new TestConnectionCallbacks();
+    connectionManager.connect(null, connectionCallbacks);
+    connectionManager.onServiceDisconnected();
+    assertThat(connectionCallbacks.isConnected()).isFalse();
+  }
+
+  @Test public void onServiceDisconnected_shouldNotBeConnectingOrConnected() {
+    connectionManager.connect(null, null);
+    connectionManager.onServiceDisconnected();
+    assertThat(connectionManager.isConnected()).isFalse();
+    assertThat(connectionManager.isConnecting()).isFalse();
+  }
+
+  @Test public void onServiceDisconnected_shouldNotCallConnectionCallback() {
+    TestConnectionCallbacks connectionCallbacks = new TestConnectionCallbacks();
+    connectionCallbacks.onConnected();
+    connectionManager.onServiceDisconnected();
+    assertThat(connectionCallbacks.isConnected()).isTrue();
+  }
+
+  class TestEventCallbacks implements FusedLocationServiceConnectionManager.EventCallbacks {
+
+    private boolean connected = false;
+    private boolean serviceConnected = false;
+
+    @Override public void onConnect(Context context) {
+      connected = true;
+    }
+
+    @Override public void onServiceConnected(IBinder binder) {
+      serviceConnected = true;
+    }
+
+    @Override
+    public void onDisconnect(LostApiClient client, boolean stopService, boolean disconnectService) {
+      connected = false;
+    }
+  }
+}

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestConnectionCallbacks.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestConnectionCallbacks.java
@@ -5,16 +5,37 @@ import com.mapzen.android.lost.api.LostApiClient;
 class TestConnectionCallbacks implements LostApiClient.ConnectionCallbacks {
 
   private boolean connected = false;
+  private FusedLocationServiceConnectionManager connectionManager;
+  private boolean managerConnectedOnConnect = false;
+  private boolean idleOnDisconnected = false;
+
+  public void setConnectionManager(FusedLocationServiceConnectionManager manager) {
+    connectionManager = manager;
+  }
 
   @Override public void onConnected() {
     connected = true;
+    if (connectionManager != null) {
+      managerConnectedOnConnect = connectionManager.isConnected();
+    }
   }
 
   @Override public void onConnectionSuspended() {
     connected = false;
+    if (connectionManager != null) {
+      idleOnDisconnected = !connectionManager.isConnected() && !connectionManager.isConnecting();
+    }
   }
 
   public boolean isConnected() {
     return connected;
+  }
+
+  public boolean isManagerConnectedOnConnect() {
+    return managerConnectedOnConnect;
+  }
+
+  public boolean isIdleOnDisconnected() {
+    return idleOnDisconnected;
   }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestConnectionCallbacks.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestConnectionCallbacks.java
@@ -1,0 +1,20 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LostApiClient;
+
+class TestConnectionCallbacks implements LostApiClient.ConnectionCallbacks {
+
+  private boolean connected = false;
+
+  @Override public void onConnected() {
+    connected = true;
+  }
+
+  @Override public void onConnectionSuspended() {
+    connected = false;
+  }
+
+  public boolean isConnected() {
+    return connected;
+  }
+}


### PR DESCRIPTION
### Overview
This PR updates the internal connection state for the `FusedLocationProviderApi` before invoking any callbacks. Previously, callbacks were invoked before the state was updated which caused bugs when client logic in callbacks relied on checking `LostApiClient#isConnected`.

### Proposed Changes
This work extracts non-service related logic from `FusedLocationProviderApiImpl` into a new class, `FusedLocationServiceConnectionManager` and adds test coverage for the new class.

Resolves problem described here: https://github.com/mapzen/android/issues/208