### PR TITLE
Prevent crash due to attempting to unbind service when not currently bound

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
@@ -41,7 +41,6 @@ public interface ClientManager {
   void reportProviderDisabled(String provider);
   void notifyLocationAvailability(final LocationAvailability availability);
   boolean hasNoListeners();
-  void disconnect(LostApiClient client);
   void shutdown();
   Map<LostApiClient, Set<LocationListener>> getLocationListeners();
   Map<LostApiClient, Set<PendingIntent>> getPendingIntents();

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -52,10 +52,7 @@ public class FusedLocationProviderApiImpl
       }
     }
 
-    @Override public void onDisconnect(LostApiClient client, boolean disconnectService) {
-      if (disconnectService) {
-        service.disconnect(client);
-      }
+    @Override public void onDisconnect() {
       context.unbindService(serviceConnection);
       Intent intent = new Intent(context, FusedLocationProviderService.class);
       context.stopService(intent);
@@ -90,8 +87,8 @@ public class FusedLocationProviderApiImpl
     serviceConnectionManager.connect(context, callbacks);
   }
 
-  public void disconnect(LostApiClient client) {
-    serviceConnectionManager.disconnect(client);
+  public void disconnect() {
+    serviceConnectionManager.disconnect();
   }
 
   public boolean isConnected() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -53,6 +53,7 @@ public class FusedLocationProviderApiImpl
   @Override public void onDisconnect() {
     if (isBound) {
       context.unbindService(this);
+      isBound = false;
     }
 
     Intent intent = new Intent(context, FusedLocationProviderService.class);

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
@@ -113,8 +113,4 @@ public class FusedLocationProviderService extends Service {
   public Map<LostApiClient, Set<LocationListener>> getLocationListeners() {
     return serviceImpl.getLocationListeners();
   }
-
-  public void disconnect(LostApiClient client) {
-    serviceImpl.disconnect(client);
-  }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
@@ -157,10 +157,6 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
     return clientManager.getLocationCallbacks();
   }
 
-  public void disconnect(LostApiClient client) {
-    clientManager.disconnect(client);
-  }
-
   /**
    * Checks if any listeners or pending intents are still registered for location updates. If not,
    * then shutdown the location engines.

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
@@ -14,7 +14,7 @@ public class FusedLocationServiceConnectionManager {
   public interface EventCallbacks {
     void onConnect(Context context);
     void onServiceConnected(IBinder binder);
-    void onDisconnect(LostApiClient client, boolean disconnectService);
+    void onDisconnect();
   }
 
   private enum ConnectState { IDLE, CONNECTING, CONNECTED }
@@ -57,12 +57,12 @@ public class FusedLocationServiceConnectionManager {
     addCallbacks(callbacks);
   }
 
-  public void disconnect(LostApiClient client) {
+  public void disconnect() {
     if (connectState != ConnectState.IDLE) {
       boolean disconnectService = (connectState == ConnectState.CONNECTED);
       connectState = ConnectState.IDLE;
       if (eventCallbacks != null) {
-        eventCallbacks.onDisconnect(client, disconnectService);
+        eventCallbacks.onDisconnect();
       }
     }
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
@@ -59,7 +59,6 @@ public class FusedLocationServiceConnectionManager {
 
   public void disconnect() {
     if (connectState != ConnectState.IDLE) {
-      boolean disconnectService = (connectState == ConnectState.CONNECTED);
       connectState = ConnectState.IDLE;
       if (eventCallbacks != null) {
         eventCallbacks.onDisconnect();

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
@@ -23,10 +23,12 @@ public class LostApiClientImpl implements LostApiClient {
     if (!geofencingApi.isConnected()) {
       geofencingApi.connect(context);
     }
+
     SettingsApiImpl settingsApi = getSettingsApiImpl();
     if (!settingsApi.isConnected()) {
       settingsApi.connect(context);
     }
+
     FusedLocationProviderApiImpl fusedApi = getFusedLocationProviderApiImpl();
     if (fusedApi.isConnected()) {
       if (connectionCallbacks != null) {
@@ -39,6 +41,7 @@ public class LostApiClientImpl implements LostApiClient {
     } else {
       fusedApi.connect(context, connectionCallbacks);
     }
+
     clientManager.addClient(this);
   }
 
@@ -50,7 +53,7 @@ public class LostApiClientImpl implements LostApiClient {
 
     getSettingsApiImpl().disconnect();
     getGeofencingImpl().disconnect();
-    getFusedLocationProviderApiImpl().disconnect(null);
+    getFusedLocationProviderApiImpl().disconnect();
   }
 
   @Override public boolean isConnected() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
@@ -61,6 +61,10 @@ public class LostClientManager implements ClientManager {
 
   public void removeClient(LostApiClient client) {
     clients.remove(client);
+    clientToListeners.remove(client);
+    clientToPendingIntents.remove(client);
+    clientToLocationCallbacks.remove(client);
+    clientCallbackToLoopers.remove(client);
   }
 
   public int numberOfClients() {
@@ -241,13 +245,6 @@ public class LostClientManager implements ClientManager {
   public boolean hasNoListeners() {
     return clientToListeners.isEmpty() && clientToPendingIntents.isEmpty() &&
         clientToLocationCallbacks.isEmpty();
-  }
-
-  public void disconnect(LostApiClient client) {
-    clientToListeners.remove(client);
-    clientToPendingIntents.remove(client);
-    clientToLocationCallbacks.remove(client);
-    clientCallbackToLoopers.remove(client);
   }
 
   public void shutdown() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -198,12 +199,6 @@ public class FusedLocationProviderApiImplTest {
   @Test public void onDisconnect_shouldUnbindServiceIfBound() throws Exception {
     Context context = mock(Context.class);
     api.onConnect(context);
-
-    FusedLocationProviderService.FusedLocationProviderBinder binder =
-        mock(FusedLocationProviderService.FusedLocationProviderBinder.class);
-    when(binder.getService()).thenReturn(mock(FusedLocationProviderService.class));
-    api.onServiceConnected(binder);
-
     api.onDisconnect();
     verify(context).unbindService(api);
   }
@@ -211,8 +206,8 @@ public class FusedLocationProviderApiImplTest {
   @Test public void onDisconnect_shouldNotUnbindServiceIfNotBound() throws Exception {
     Context context = mock(Context.class);
     api.onConnect(context);
-
+    api.onServiceDisconnected(mock(ComponentName.class));
     api.onDisconnect();
-    verify(context).unbindService(api);
+    verify(context, never()).unbindService(api);
   }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.robolectric.RuntimeEnvironment.application;
@@ -209,5 +210,13 @@ public class FusedLocationProviderApiImplTest {
     api.onServiceDisconnected(mock(ComponentName.class));
     api.onDisconnect();
     verify(context, never()).unbindService(api);
+  }
+
+  @Test public void onDisconnect_shouldNotAttemptToUnbindServiceMoreThanOnce() throws Exception {
+    Context context = mock(Context.class);
+    api.onConnect(context);
+    api.onDisconnect();
+    api.onDisconnect();
+    verify(context, times(1)).unbindService(api);
   }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -1,11 +1,5 @@
 package com.mapzen.android.lost.internal;
 
-import android.app.PendingIntent;
-import android.content.ComponentName;
-import android.content.Context;
-import android.location.Location;
-import android.os.Looper;
-
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LostApiClient;
@@ -17,6 +11,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
+
+import android.app.PendingIntent;
+import android.content.ComponentName;
+import android.content.Context;
+import android.location.Location;
+import android.os.Looper;
 
 import java.io.File;
 
@@ -94,9 +94,8 @@ public class FusedLocationProviderApiImplTest {
   }
 
   @Test public void disconnect_shouldCallConnectionManager() {
-    LostApiClient client = mock(LostApiClient.class);
-    api.disconnect(client);
-    verify(connectionManager).disconnect(client);
+    api.disconnect();
+    verify(connectionManager).disconnect();
   }
 
   @Test public void isConnected_shouldCallConnectionManager() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
@@ -813,36 +813,6 @@ public class FusedLocationProviderServiceImplTest {
     assertThat(otherCallback.getAvailability()).isNull();
   }
 
-  @Test public void disconnect_otherClientShouldHavePendingIntents() {
-    client.connect();
-    otherClient.connect();
-    api.requestLocationUpdates(otherClient, LocationRequest.create(),
-        mock(PendingIntent.class));
-    api.disconnect(client);
-
-    assertThat(api.getPendingIntents().get(otherClient)).isNotNull();
-  }
-
-  @Test public void disconnect_otherClientShouldHaveListeners() {
-    client.connect();
-    otherClient.connect();
-    api.requestLocationUpdates(otherClient, LocationRequest.create(),
-        new TestLocationListener());
-    api.disconnect(client);
-
-    assertThat(api.getLocationListeners().get(otherClient)).isNotNull();
-  }
-
-  @Test public void disconnect_otherClientShouldHaveLocationListeners() {
-    client.connect();
-    otherClient.connect();
-    api.requestLocationUpdates(otherClient, LocationRequest.create(),
-        new TestLocationCallback(), Looper.myLooper());
-    api.disconnect(client);
-
-    assertThat(api.getLocationCallbacks().get(otherClient)).isNotNull();
-  }
-
   @Test public void requestLocationUpdates_listener_shouldReturnFusedLocationPendingResult() {
     TestLocationListener listener = new TestLocationListener();
     PendingResult<Status> result = api.requestLocationUpdates(client, LocationRequest.create(),

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManagerTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManagerTest.java
@@ -1,7 +1,5 @@
 package com.mapzen.android.lost.internal;
 
-import com.mapzen.android.lost.api.LostApiClient;
-
 import org.junit.Test;
 
 import android.content.Context;
@@ -82,7 +80,7 @@ public class FusedLocationServiceConnectionManagerTest {
 
   @Test public void disconnect_shouldNotSetStateConnectingConnected() {
     connectionManager.connect(null, null);
-    connectionManager.disconnect(null);
+    connectionManager.disconnect();
     assertThat(connectionManager.isConnecting()).isFalse();
     assertThat(connectionManager.isConnected()).isFalse();
   }
@@ -91,7 +89,7 @@ public class FusedLocationServiceConnectionManagerTest {
     TestEventCallbacks callbacks = new TestEventCallbacks();
     connectionManager.setEventCallbacks(callbacks);
     connectionManager.connect(null, null);
-    connectionManager.disconnect(null);
+    connectionManager.disconnect();
     assertThat(callbacks.connected).isFalse();
   }
 
@@ -99,7 +97,7 @@ public class FusedLocationServiceConnectionManagerTest {
     TestEventCallbacks callbacks = new TestEventCallbacks();
     connectionManager.setEventCallbacks(callbacks);
     connectionManager.connect(null, null);
-    connectionManager.disconnect(null);
+    connectionManager.disconnect();
     assertThat(callbacks.idleOnDisconnect).isTrue();
   }
 
@@ -107,7 +105,7 @@ public class FusedLocationServiceConnectionManagerTest {
     TestEventCallbacks callbacks = new TestEventCallbacks();
     callbacks.onConnect(null);
     connectionManager.setEventCallbacks(callbacks);
-    connectionManager.disconnect(null);
+    connectionManager.disconnect();
     assertThat(callbacks.connected).isTrue();
   }
 
@@ -206,7 +204,7 @@ public class FusedLocationServiceConnectionManagerTest {
     }
 
     @Override
-    public void onDisconnect(LostApiClient client, boolean disconnectService) {
+    public void onDisconnect() {
       connected = false;
       idleOnDisconnect = !connectionManager.isConnected() && !connectionManager.isConnecting();
     }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostClientManagerTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostClientManagerTest.java
@@ -198,28 +198,28 @@ public class LostClientManagerTest {
     assertThat(manager.hasNoListeners()).isFalse();
   }
 
-  @Test public void disconnect_shouldRemoveListenersForClient() {
+  @Test public void removeClient_shouldRemoveListenersForClient() {
     LocationRequest request = LocationRequest.create();
     TestLocationListener listener = new TestLocationListener();
     manager.addListener(client, request, listener);
-    manager.disconnect(client);
+    manager.removeClient(client);
     assertThat(manager.getLocationListeners().get(client)).isNull();
   }
 
-  @Test public void disconnect_shouldRemovePendingIntentsForClient() {
+  @Test public void removeClient_shouldRemovePendingIntentsForClient() {
     LocationRequest request = LocationRequest.create();
     PendingIntent pendingIntent = mock(PendingIntent.class);
     manager.addPendingIntent(client, request, pendingIntent);
-    manager.disconnect(client);
+    manager.removeClient(client);
     assertThat(manager.getPendingIntents().get(client)).isNull();
   }
 
-  @Test public void disconnect_shouldRemoveCallbacksForClient() {
+  @Test public void removeClient_shouldRemoveCallbacksForClient() {
     LocationRequest request = LocationRequest.create();
     TestLocationCallback callback = new TestLocationCallback();
     Looper looper = mock(Looper.class);
     manager.addLocationCallback(client, request, callback, looper);
-    manager.disconnect(client);
+    manager.removeClient(client);
     assertThat(manager.getLocationCallbacks().get(client)).isNull();
   }
 


### PR DESCRIPTION
### Overview

Prevent crash due to attempting to unbind service when not currently bound. Simplify logic to disconnect fused location client and service.

### Proposed Changes

* Combines the responsibilities from `LostClientManager.removeClient(LostApiClient)` and `LostClientManager.disconnect(LostApiClient)` into a single method.
* Actively track whether service is currently bound in `FusedLocationProviderApiImpl` to prevent attempts to unbind when service is not bound. Fixes `IllegalArgumentException`.
* Removes client param to `FusedLocationServiceConnectionManager.disconnect()` since it was only ever called with `null`.
* Removes `FusedLocationProviderService.disconnect(LostApiClient)` since disconnecting the client is now handled by `LostClientManager.removeClient(LostApiClient)` called before disconnecting the service.
* Adds tests for `EventCallbacks` methods in `FusedLocationProviderApiImpl`.

Closes #132 