### PR TITLE
Better is connected logic for multiple clients

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
@@ -24,6 +24,7 @@ public interface ClientManager {
 
   void addClient(LostApiClient client);
   void removeClient(LostApiClient client);
+  boolean containsClient(LostApiClient client);
   int numberOfClients();
   void addListener(LostApiClient client, LocationRequest request, LocationListener listener);
   void addPendingIntent(LostApiClient client, LocationRequest request,

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
@@ -58,7 +58,7 @@ public class LostApiClientImpl implements LostApiClient {
 
   @Override public boolean isConnected() {
     return getGeofencingImpl().isConnected() && getSettingsApiImpl().isConnected()
-        && getFusedLocationProviderApiImpl().isConnected();
+        && getFusedLocationProviderApiImpl().isConnected() && clientManager.containsClient(this);
   }
 
   private GeofencingApiImpl getGeofencingImpl() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
@@ -67,6 +67,10 @@ public class LostClientManager implements ClientManager {
     clientCallbackToLoopers.remove(client);
   }
 
+  public boolean containsClient(LostApiClient client) {
+    return clients.contains(client);
+  }
+
   public int numberOfClients() {
     return clients.size();
   }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -166,7 +166,8 @@ public class LostApiClientImplTest {
     assertThat(client.isConnected()).isFalse();
   }
 
-  @Test public void isConnected_multipleClients_shouldReturnFalseAfterDisconnected() throws Exception {
+  @Test public void isConnected_multipleClients_shouldReturnFalseAfterDisconnected() throws
+      Exception {
     LostApiClient anotherClient = new LostApiClient.Builder(application).build();
     anotherClient.connect();
     client.connect();

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -150,7 +150,6 @@ public class LostApiClientImplTest {
     anotherClient.disconnect();
   }
 
-
   @Test
   public void isConnected_shouldReturnFalseBeforeConnected() throws Exception {
     assertThat(client.isConnected()).isFalse();
@@ -166,4 +165,14 @@ public class LostApiClientImplTest {
     client.disconnect();
     assertThat(client.isConnected()).isFalse();
   }
+
+  @Test public void isConnected_multipleClients_shouldReturnFalseAfterDisconnected() throws Exception {
+    LostApiClient anotherClient = new LostApiClient.Builder(application).build();
+    anotherClient.connect();
+    client.connect();
+    client.disconnect();
+    assertThat(client.isConnected()).isFalse();
+    anotherClient.disconnect();
+  }
+
 }


### PR DESCRIPTION
### Overview
This PR updates how `LostApiClient#isConnected` is determined to consider whether the client is being managed by the `ClientManager`.

### Proposed Changes
This fixes a bug where when multiple clients were connected, the method would report that unbound clients were connected.

Closes #134 
