### PR TITLE
Better callback invocation

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/api/LostApiClient.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LostApiClient.java
@@ -1,6 +1,7 @@
 package com.mapzen.android.lost.api;
 
 import com.mapzen.android.lost.internal.LostApiClientImpl;
+import com.mapzen.android.lost.internal.LostClientManager;
 
 import android.content.Context;
 
@@ -31,7 +32,7 @@ public interface LostApiClient {
     }
 
     public LostApiClient build() {
-      return new LostApiClientImpl(context, connectionCallbacks);
+      return new LostApiClientImpl(context, connectionCallbacks, LostClientManager.shared());
     }
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
@@ -47,6 +47,7 @@ public class FusedLocationServiceConnectionManager {
   }
 
   public void connect(Context context, ConnectionCallbacks callbacks) {
+    addCallbacks(callbacks);
     if (connectState == ConnectState.IDLE) {
       connectState = ConnectState.CONNECTING;
 
@@ -54,7 +55,6 @@ public class FusedLocationServiceConnectionManager {
         eventCallbacks.onConnect(context);
       }
     }
-    addCallbacks(callbacks);
   }
 
   public void disconnect() {
@@ -90,5 +90,9 @@ public class FusedLocationServiceConnectionManager {
         }
       }
     }
+  }
+
+  public Set<ConnectionCallbacks> getConnectionCallbacks() {
+    return connectionCallbacks;
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
@@ -11,11 +11,13 @@ import android.content.Context;
 public class LostApiClientImpl implements LostApiClient {
   private final Context context;
   private final ConnectionCallbacks connectionCallbacks;
-  private final ClientManager clientManager = LostClientManager.shared();
+  private final ClientManager clientManager;
 
-  public LostApiClientImpl(Context context, ConnectionCallbacks callbacks) {
+  public LostApiClientImpl(Context context, ConnectionCallbacks callbacks,
+      ClientManager clientManager) {
     this.context = context;
     this.connectionCallbacks = callbacks;
+    this.clientManager = clientManager;
   }
 
   @Override public void connect() {
@@ -41,7 +43,6 @@ public class LostApiClientImpl implements LostApiClient {
     } else {
       fusedApi.connect(context, connectionCallbacks);
     }
-
     clientManager.addClient(this);
   }
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
@@ -21,6 +21,8 @@ public class LostApiClientImpl implements LostApiClient {
   }
 
   @Override public void connect() {
+    clientManager.addClient(this);
+
     GeofencingApiImpl geofencingApi = getGeofencingImpl();
     if (!geofencingApi.isConnected()) {
       geofencingApi.connect(context);
@@ -43,7 +45,6 @@ public class LostApiClientImpl implements LostApiClient {
     } else {
       fusedApi.connect(context, connectionCallbacks);
     }
-    clientManager.addClient(this);
   }
 
   @Override public void disconnect() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -65,6 +65,24 @@ public class LostApiClientImplTest {
     assertThat(settingsApi.isConnected()).isTrue();
   }
 
+  @Test public void connect_shouldBeConnectedWhenConnectionCallbackInvoked()
+      throws Exception {
+    callbacks.setLostClient(client);
+    client.connect();
+    assertThat(callbacks.isClientConnectedOnConnect()).isTrue();
+  }
+
+  @Test public void connect_multipleClients_shouldBeConnectedWhenConnectionCallbackInvoked()
+      throws Exception {
+    client.connect();
+    TestConnectionCallbacks callbacks = new TestConnectionCallbacks();
+    LostApiClient anotherClient = new LostApiClientImpl(application, callbacks,
+        new TestClientManager());
+    callbacks.setLostClient(anotherClient);
+    anotherClient.connect();
+    assertThat(callbacks.isClientConnectedOnConnect()).isTrue();
+  }
+
   @Test public void disconnect_shouldNotRemoveFusedLocationProviderApiImpl() throws Exception {
     client.connect();
     client.disconnect();

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -28,9 +28,11 @@ import static org.robolectric.Shadows.shadowOf;
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
 public class LostApiClientImplTest {
   private LostApiClient client;
+  private TestConnectionCallbacks callbacks;
 
   @Before public void setUp() throws Exception {
-    client = new LostApiClient.Builder(application).build();
+    callbacks = new TestConnectionCallbacks();
+    client = new LostApiClientImpl(application, callbacks, new TestClientManager());
 
     FusedLocationProviderService.FusedLocationProviderBinder stubBinder = mock(
         FusedLocationProviderService.FusedLocationProviderBinder.class);
@@ -124,30 +126,30 @@ public class LostApiClientImplTest {
 
   @Test public void disconnect_multipleClients_shouldNotRemoveFusedLocationProviderApiImpl()
       throws Exception {
-    LostApiClient anotherClient = new LostApiClient.Builder(application).build();
+    LostApiClient anotherClient = new LostApiClientImpl(application, callbacks,
+        new TestClientManager());
     anotherClient.connect();
     client.connect();
     client.disconnect();
     assertThat(LocationServices.FusedLocationApi).isNotNull();
-    anotherClient.disconnect();
   }
 
   @Test public void disconnect_multipleClients_shouldNotRemoveGeofencingApiImpl() throws Exception {
-    LostApiClient anotherClient = new LostApiClient.Builder(application).build();
+    LostApiClient anotherClient = new LostApiClientImpl(application, callbacks,
+        new TestClientManager());
     anotherClient.connect();
     client.connect();
     client.disconnect();
     assertThat(LocationServices.GeofencingApi).isNotNull();
-    anotherClient.disconnect();
   }
 
   @Test public void disconnect_multipleClients_shouldNotRemoveSettingsApiImpl() throws Exception {
-    LostApiClient anotherClient = new LostApiClient.Builder(application).build();
+    LostApiClient anotherClient = new LostApiClientImpl(application, callbacks,
+        new TestClientManager());
     anotherClient.connect();
     client.connect();
     client.disconnect();
     assertThat(LocationServices.SettingsApi).isNotNull();
-    anotherClient.disconnect();
   }
 
   @Test
@@ -168,12 +170,12 @@ public class LostApiClientImplTest {
 
   @Test public void isConnected_multipleClients_shouldReturnFalseAfterDisconnected() throws
       Exception {
-    LostApiClient anotherClient = new LostApiClient.Builder(application).build();
+    LostApiClient anotherClient = new LostApiClientImpl(application, callbacks,
+        new TestClientManager());
     anotherClient.connect();
     client.connect();
     client.disconnect();
     assertThat(client.isConnected()).isFalse();
-    anotherClient.disconnect();
   }
 
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestClientManager.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestClientManager.java
@@ -1,0 +1,110 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationCallback;
+import com.mapzen.android.lost.api.LocationListener;
+import com.mapzen.android.lost.api.LocationRequest;
+import com.mapzen.android.lost.api.LocationResult;
+import com.mapzen.android.lost.api.LostApiClient;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.location.Location;
+import android.os.Looper;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class TestClientManager implements ClientManager {
+
+  private HashSet<LostApiClient> clients = new HashSet<>();
+
+  @Override public void addClient(LostApiClient client) {
+    clients.add(client);
+  }
+
+  @Override public void removeClient(LostApiClient client) {
+    clients.remove(client);
+  }
+
+  @Override public boolean containsClient(LostApiClient client) {
+    return clients.contains(client);
+  }
+
+  @Override public int numberOfClients() {
+    return clients.size();
+  }
+
+  @Override public void addListener(LostApiClient client, LocationRequest request,
+      LocationListener listener) {
+
+  }
+
+  @Override public void addPendingIntent(LostApiClient client, LocationRequest request,
+      PendingIntent callbackIntent) {
+
+  }
+
+  @Override public void addLocationCallback(LostApiClient client, LocationRequest request,
+      LocationCallback callback, Looper looper) {
+
+  }
+
+  @Override public boolean removeListener(LostApiClient client, LocationListener listener) {
+    return false;
+  }
+
+  @Override public boolean removePendingIntent(LostApiClient client, PendingIntent callbackIntent) {
+    return false;
+  }
+
+  @Override public boolean removeLocationCallback(LostApiClient client, LocationCallback callback) {
+    return false;
+  }
+
+  @Override public void reportLocationChanged(Location location) {
+
+  }
+
+  @Override public void sendPendingIntent(Context context, Location location,
+      LocationAvailability availability, LocationResult result) {
+
+  }
+
+  @Override public void reportLocationResult(LocationResult result) {
+
+  }
+
+  @Override public void reportProviderEnabled(String provider) {
+
+  }
+
+  @Override public void reportProviderDisabled(String provider) {
+
+  }
+
+  @Override public void notifyLocationAvailability(LocationAvailability availability) {
+
+  }
+
+  @Override public boolean hasNoListeners() {
+    return false;
+  }
+
+  @Override public void shutdown() {
+
+  }
+
+  @Override public Map<LostApiClient, Set<LocationListener>> getLocationListeners() {
+    return null;
+  }
+
+  @Override public Map<LostApiClient, Set<PendingIntent>> getPendingIntents() {
+    return null;
+  }
+
+  @Override public Map<LostApiClient, Set<LocationCallback>> getLocationCallbacks() {
+    return null;
+  }
+}

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestConnectionCallbacks.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestConnectionCallbacks.java
@@ -8,15 +8,24 @@ class TestConnectionCallbacks implements LostApiClient.ConnectionCallbacks {
   private FusedLocationServiceConnectionManager connectionManager;
   private boolean managerConnectedOnConnect = false;
   private boolean idleOnDisconnected = false;
+  private LostApiClient client;
+  private boolean clientConnectedOnConnect = false;
 
   public void setConnectionManager(FusedLocationServiceConnectionManager manager) {
     connectionManager = manager;
+  }
+
+  public void setLostClient(LostApiClient c) {
+    client = c;
   }
 
   @Override public void onConnected() {
     connected = true;
     if (connectionManager != null) {
       managerConnectedOnConnect = connectionManager.isConnected();
+    }
+    if (client != null) {
+      clientConnectedOnConnect = client.isConnected();
     }
   }
 
@@ -37,5 +46,9 @@ class TestConnectionCallbacks implements LostApiClient.ConnectionCallbacks {
 
   public boolean isIdleOnDisconnected() {
     return idleOnDisconnected;
+  }
+
+  public boolean isClientConnectedOnConnect() {
+    return clientConnectedOnConnect;
   }
 }


### PR DESCRIPTION
### Overview
This PR fixes bugs that occur when checking `LostApiClient` connection state in callbacks.

### Proposed Changes
This changes `FusedLocationServiceConnectionManager` and `LostApiClientImpl` to update their internal state before invoking external callbacks. It also migrates `LostApiClientImpl` to have its `ClientManager` injected and cleans up related tests.