### PR TITLE
Location provider enabled/disabled

### DIFF
--- a/lost-sample/src/main/AndroidManifest.xml
+++ b/lost-sample/src/main/AndroidManifest.xml
@@ -36,7 +36,8 @@
     <activity android:name=".SettingsApiActivity"/>
     <activity android:name=".LocationListenerActivity"/>
     <activity android:name=".PendingIntentActivity"/>
-    
+    <activity android:name=".LocationAvailabilityActivity"/>
+
     <service
         android:name=".GeofenceIntentService"
         android:exported="false">

--- a/lost-sample/src/main/java/com/example/lost/LocationAvailabilityActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/LocationAvailabilityActivity.java
@@ -1,0 +1,60 @@
+package com.example.lost;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.Button;
+import android.widget.Toast;
+
+import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationServices;
+import com.mapzen.android.lost.api.LostApiClient;
+
+public class LocationAvailabilityActivity extends AppCompatActivity {
+
+    LostApiClient client;
+
+    @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_location_availability);
+
+        setupLocationAvailabilityBtn();
+    }
+
+    private void setupLocationAvailabilityBtn() {
+        Button connect = (Button) findViewById(R.id.check_availability);
+        connect.setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View v) {
+                if (client == null || !client.isConnected()) {
+                    connect();
+                } else {
+                    checkLocationAvailability();
+                }
+            }
+        });
+    }
+
+    private void connect() {
+        client = new LostApiClient.Builder(this).addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
+            @Override
+            public void onConnected() {
+                checkLocationAvailability();
+            }
+
+            @Override
+            public void onConnectionSuspended() {
+
+            }
+        }).build();
+        client.connect();
+    }
+
+    private void checkLocationAvailability() {
+        LocationAvailability availability =
+                LocationServices.FusedLocationApi.getLocationAvailability(client);
+        boolean isAvailable = availability.isLocationAvailable();
+        Toast.makeText(LocationAvailabilityActivity.this, isAvailable ? R.string.location_available
+                : R.string.location_unavailable, Toast.LENGTH_SHORT).show();
+    }
+}

--- a/lost-sample/src/main/java/com/example/lost/LocationAvailabilityActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/LocationAvailabilityActivity.java
@@ -1,6 +1,7 @@
 package com.example.lost;
 
 import android.os.Bundle;
+import android.os.Looper;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -8,12 +9,31 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationCallback;
+import com.mapzen.android.lost.api.LocationRequest;
+import com.mapzen.android.lost.api.LocationResult;
 import com.mapzen.android.lost.api.LocationServices;
 import com.mapzen.android.lost.api.LostApiClient;
+
+import static com.mapzen.android.lost.api.LocationRequest.PRIORITY_HIGH_ACCURACY;
 
 public class LocationAvailabilityActivity extends AppCompatActivity {
 
     LostApiClient client;
+
+    LocationCallback callback = new LocationCallback() {
+        @Override
+        public void onLocationAvailability(LocationAvailability locationAvailability) {
+            boolean isAvailable = locationAvailability.isLocationAvailable();
+            Toast.makeText(LocationAvailabilityActivity.this, isAvailable ? R.string.location_available
+                    : R.string.location_unavailable, Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
+        public void onLocationResult(LocationResult result) {
+
+        }
+    };
 
     @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -56,5 +76,11 @@ public class LocationAvailabilityActivity extends AppCompatActivity {
         boolean isAvailable = availability.isLocationAvailable();
         Toast.makeText(LocationAvailabilityActivity.this, isAvailable ? R.string.location_available
                 : R.string.location_unavailable, Toast.LENGTH_SHORT).show();
+
+        final LocationRequest locationRequest = LocationRequest.create()
+                .setPriority(PRIORITY_HIGH_ACCURACY);
+        LocationServices.FusedLocationApi.requestLocationUpdates(client, locationRequest, callback,
+                Looper.myLooper());
+
     }
 }

--- a/lost-sample/src/main/java/com/example/lost/LocationAvailabilityActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/LocationAvailabilityActivity.java
@@ -25,8 +25,9 @@ public class LocationAvailabilityActivity extends AppCompatActivity {
         @Override
         public void onLocationAvailability(LocationAvailability locationAvailability) {
             boolean isAvailable = locationAvailability.isLocationAvailable();
-            Toast.makeText(LocationAvailabilityActivity.this, isAvailable ? R.string.location_available
-                    : R.string.location_unavailable, Toast.LENGTH_SHORT).show();
+            Toast.makeText(LocationAvailabilityActivity.this, isAvailable ?
+                    R.string.location_available : R.string.location_unavailable,
+                    Toast.LENGTH_SHORT).show();
         }
 
         @Override
@@ -56,7 +57,8 @@ public class LocationAvailabilityActivity extends AppCompatActivity {
     }
 
     private void connect() {
-        client = new LostApiClient.Builder(this).addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
+        client = new LostApiClient.Builder(this).addConnectionCallbacks(
+                new LostApiClient.ConnectionCallbacks() {
             @Override
             public void onConnected() {
                 checkLocationAvailability();

--- a/lost-sample/src/main/java/com/example/lost/SamplesList.java
+++ b/lost-sample/src/main/java/com/example/lost/SamplesList.java
@@ -18,6 +18,8 @@ public class SamplesList {
       new Sample(R.string.sample_location_listener_title,
           R.string.sample_location_listener_description, LocationListenerActivity.class),
       new Sample(R.string.sample_pending_intent_title,
-          R.string.sample_pending_intent_description, PendingIntentActivity.class)
+          R.string.sample_pending_intent_description, PendingIntentActivity.class),
+      new Sample(R.string.sample_location_availability_title,
+          R.string.sample_location_availability_description, LocationAvailabilityActivity.class)
   };
 }

--- a/lost-sample/src/main/res/layout/activity_location_availability.xml
+++ b/lost-sample/src/main/res/layout/activity_location_availability.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/check_availability"
+        android:text="@string/check_availability"/>
+
+</LinearLayout>

--- a/lost-sample/src/main/res/values/strings.xml
+++ b/lost-sample/src/main/res/values/strings.xml
@@ -71,5 +71,10 @@
   <string name="sample_pending_intent_title">PendingIntent</string>
   <string name="sample_pending_intent_description">Demonstrates how to use a PendingIntent to receive location updates</string>
   <string name="requested">Requested</string>
+  <string name="sample_location_availability_title">Location Availability</string>
+  <string name="sample_location_availability_description">Demonstrates how to determine if location requested is available</string>
+  <string name="check_availability">Check Availability</string>
+  <string name="location_available">Location Available</string>
+  <string name="location_unavailable">Location NOT Available</string>
 
 </resources>

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationListener.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationListener.java
@@ -1,6 +1,7 @@
 package com.mapzen.android.lost.api;
 
 import android.location.Location;
+import android.os.Looper;
 
 /**
  * Used for receiving notifications from the FusedLocationProviderApi when the location has changed.
@@ -17,14 +18,28 @@ public interface LocationListener {
   void onLocationChanged(Location location);
 
   /**
-   * Called when a location provider is disabled.
+   * Called when a location provider is disabled. You will only receive updates for the priority
+   * level set in the location request used to register for updates in
+   * {@link FusedLocationProviderApi#requestLocationUpdates(LostApiClient, LocationRequest,
+   * LocationListener)}. Ie. {@link LocationRequest#PRIORITY_HIGH_ACCURACY} will invoke this method
+   * for gps and network changes but {@link LocationRequest#PRIORITY_BALANCED_POWER_ACCURACY} will
+   * only invoke it for network changes. This method will be removed in the next major release, it
+   * is recommended that you use {@link LocationAvailability} instead.
    * @param provider the disabled provider.
    */
+  @Deprecated
   void onProviderDisabled(String provider);
 
   /**
-   * Called when a location provider is enabled.
+   * Called when a location provider is enabled. You will only receive updates for the priority
+   * level set in the location request used to register for updates in
+   * {@link FusedLocationProviderApi#requestLocationUpdates(LostApiClient, LocationRequest,
+   * LocationListener)}. Ie. {@link LocationRequest#PRIORITY_HIGH_ACCURACY} will invoke this method
+   * for gps and network changes but {@link LocationRequest#PRIORITY_BALANCED_POWER_ACCURACY} will
+   * only invoke it for network changes. This method will be removed in the next major release, it
+   * is recommended that you use {@link LocationAvailability} instead.
    * @param provider the enabled provider.
    */
+  @Deprecated
   void onProviderEnabled(String provider);
 }

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationListener.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationListener.java
@@ -1,7 +1,6 @@
 package com.mapzen.android.lost.api;
 
 import android.location.Location;
-import android.os.Looper;
 
 /**
  * Used for receiving notifications from the FusedLocationProviderApi when the location has changed.

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
@@ -12,6 +12,8 @@ import com.mapzen.android.lost.api.Status;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.location.Location;
+import android.location.LocationManager;
+import android.os.Bundle;
 import android.os.Looper;
 import android.support.annotation.RequiresPermission;
 
@@ -143,6 +145,28 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
   public void reportProviderEnabled(String provider) {
     clientManager.reportProviderEnabled(provider);
     notifyLocationAvailabilityChanged();
+    LocationManager manager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+    manager.requestSingleUpdate(provider, new android.location.LocationListener() {
+      @Override
+      public void onLocationChanged(Location location) {
+        notifyLocationAvailabilityChanged();
+      }
+
+      @Override
+      public void onStatusChanged(String s, int i, Bundle bundle) {
+
+      }
+
+      @Override
+      public void onProviderEnabled(String s) {
+
+      }
+
+      @Override
+      public void onProviderDisabled(String s) {
+
+      }
+    }, Looper.myLooper());
   }
 
   public Map<LostApiClient, Set<LocationListener>> getLocationListeners() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
@@ -1,5 +1,17 @@
 package com.mapzen.android.lost.internal;
 
+import android.app.IntentService;
+import android.app.PendingIntent;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.location.Location;
+import android.location.LocationManager;
+import android.os.Environment;
+import android.os.Looper;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import com.mapzen.android.lost.api.LocationAvailability;
 import com.mapzen.android.lost.api.LocationCallback;
 import com.mapzen.android.lost.api.LocationListener;
@@ -11,9 +23,6 @@ import com.mapzen.android.lost.api.Status;
 import com.mapzen.android.lost.shadows.LostShadowLocationManager;
 import com.mapzen.lost.BuildConfig;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,23 +33,10 @@ import org.robolectric.internal.ShadowExtractor;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowEnvironment;
 import org.robolectric.shadows.ShadowLooper;
-import org.robolectric.util.ReflectionHelpers;
-
-import android.app.IntentService;
-import android.app.PendingIntent;
-import android.content.ComponentName;
-import android.content.Context;
-import android.content.Intent;
-import android.location.Location;
-import android.location.LocationManager;
-import android.os.Environment;
-import android.os.Looper;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static android.content.Context.LOCATION_SERVICE;
@@ -57,7 +53,8 @@ import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @SuppressWarnings("MissingPermission")
-@Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE, shadows = { LostShadowLocationManager.class})
+@Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE, shadows = {
+        LostShadowLocationManager.class})
 public class FusedLocationProviderServiceImplTest {
   private LostApiClient client;
   private FusedLocationProviderServiceImpl api;

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
@@ -527,7 +527,6 @@ public class FusedLocationProviderServiceImplTest {
     PendingIntent pendingIntent1 = PendingIntent.getService(application, 0, intent, 0);
     PendingIntent pendingIntent2 = PendingIntent.getService(application, 0, intent, 0);
     api.requestLocationUpdates(client, request, pendingIntent1);
-    clearShadowLocationListeners();
     api.requestLocationUpdates(client, request, pendingIntent2);
 
     api.removeLocationUpdates(client, pendingIntent2);
@@ -996,18 +995,6 @@ public class FusedLocationProviderServiceImplTest {
     TestResultCallback otherCallback = new TestResultCallback();
     result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
     assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-  }
-
-  /**
-   * Due to a bug in Robolectric that allows the same location listener to be registered twice,
-   * we need to manually clear the `LostShadowLocationManager` to prevent duplicate listeners.
-   *
-   * @see <a href="https://github.com/robolectric/robolectric/issues/2603">
-   * LostShadowLocationManager should not allow duplicate listeners</a>
-   */
-  private void clearShadowLocationListeners() {
-    Map<String, List> map = ReflectionHelpers.getField(shadowLocationManager, "locationListeners");
-    map.clear();
   }
 
   public class TestService extends IntentService {

--- a/lost/src/test/java/com/mapzen/android/lost/shadows/LostShadowLocationManager.java
+++ b/lost/src/test/java/com/mapzen/android/lost/shadows/LostShadowLocationManager.java
@@ -61,6 +61,33 @@ public class LostShadowLocationManager {
             this.lastSeenLocation = locationAtCreation;
             this.listener = listener;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ListenerRegistration that = (ListenerRegistration) o;
+
+            if (minTime != that.minTime) return false;
+            if (Float.compare(that.minDistance, minDistance) != 0) return false;
+            if (lastSeenTime != that.lastSeenTime) return false;
+            if (!listener.equals(that.listener)) return false;
+            if (!provider.equals(that.provider)) return false;
+            return lastSeenLocation != null ? lastSeenLocation.equals(that.lastSeenLocation) : that.lastSeenLocation == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = (int) (minTime ^ (minTime >>> 32));
+            result = 31 * result + (minDistance != +0.0f ? Float.floatToIntBits(minDistance) : 0);
+            result = 31 * result + listener.hashCode();
+            result = 31 * result + provider.hashCode();
+            result = 31 * result + (lastSeenLocation != null ? lastSeenLocation.hashCode() : 0);
+            result = 31 * result + (int) (lastSeenTime ^ (lastSeenTime >>> 32));
+            return result;
+        }
     }
 
     /** Mapped by provider. */
@@ -238,8 +265,15 @@ public class LostShadowLocationManager {
             providerListeners = new ArrayList<>();
             locationListeners.put(provider, providerListeners);
         }
-        providerListeners.add(new ListenerRegistration(provider,
-                minTime, minDistance, copyOf(getLastKnownLocation(provider)), listener));
+        ListenerRegistration registrationToAdd = new ListenerRegistration(provider,
+                minTime, minDistance, copyOf(getLastKnownLocation(provider)), listener);
+        for (ListenerRegistration registration : providerListeners) {
+            if (registration.equals(registrationToAdd)) {
+                providerListeners.remove(registration);
+                break;
+            }
+        }
+        providerListeners.add(registrationToAdd);
 
     }
 

--- a/lost/src/test/java/com/mapzen/android/lost/shadows/LostShadowLocationManager.java
+++ b/lost/src/test/java/com/mapzen/android/lost/shadows/LostShadowLocationManager.java
@@ -34,8 +34,10 @@ public class LostShadowLocationManager {
 
     private final Map<String, LocationProviderEntry> providersEnabled = new LinkedHashMap<>();
     private final Map<String, Location> lastKnownLocations = new HashMap<>();
-    private final Map<PendingIntent, Criteria> requestLocationUdpateCriteriaPendingIntents = new HashMap<>();
-    private final Map<PendingIntent, String> requestLocationUdpateProviderPendingIntents = new HashMap<>();
+    private final Map<PendingIntent, Criteria> requestLocationUdpateCriteriaPendingIntents =
+            new HashMap<>();
+    private final Map<PendingIntent, String> requestLocationUdpateProviderPendingIntents =
+            new HashMap<>();
     private final ArrayList<LocationListener> removedLocationListeners = new ArrayList<>();
 
     private final ArrayList<GpsStatus.Listener> gpsStatusListeners = new ArrayList<>();
@@ -52,8 +54,8 @@ public class LostShadowLocationManager {
         Location lastSeenLocation;
         long lastSeenTime;
 
-        ListenerRegistration(String provider, long minTime, float minDistance, Location locationAtCreation,
-                             LocationListener listener) {
+        ListenerRegistration(String provider, long minTime, float minDistance, Location
+                locationAtCreation, LocationListener listener) {
             this.provider = provider;
             this.minTime = minTime;
             this.minDistance = minDistance;
@@ -64,17 +66,32 @@ public class LostShadowLocationManager {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             ListenerRegistration that = (ListenerRegistration) o;
 
-            if (minTime != that.minTime) return false;
-            if (Float.compare(that.minDistance, minDistance) != 0) return false;
-            if (lastSeenTime != that.lastSeenTime) return false;
-            if (!listener.equals(that.listener)) return false;
-            if (!provider.equals(that.provider)) return false;
-            return lastSeenLocation != null ? lastSeenLocation.equals(that.lastSeenLocation) : that.lastSeenLocation == null;
+            if (minTime != that.minTime) {
+                return false;
+            }
+            if (Float.compare(that.minDistance, minDistance) != 0) {
+                return false;
+            }
+            if (lastSeenTime != that.lastSeenTime) {
+                return false;
+            }
+            if (!listener.equals(that.listener)) {
+                return false;
+            }
+            if (!provider.equals(that.provider)) {
+                return false;
+            }
+            return lastSeenLocation != null ? lastSeenLocation.equals(that.lastSeenLocation) :
+                    that.lastSeenLocation == null;
 
         }
 
@@ -115,7 +132,8 @@ public class LostShadowLocationManager {
     }
 
     /**
-     * Sets the value to return from {@link #isProviderEnabled(String)} for the given {@code provider}
+     * Sets the value to return from {@link #isProviderEnabled(String)} for the given {@code
+     * provider}
      *
      * @param provider
      *            name of the provider whose status to set
@@ -134,7 +152,8 @@ public class LostShadowLocationManager {
         providerEntry.enabled = isEnabled;
         providerEntry.criteria = criteria;
         providersEnabled.put(provider, providerEntry);
-        List<LocationListener> locationUpdateListeners = new ArrayList<>(getRequestLocationUpdateListeners());
+        List<LocationListener> locationUpdateListeners = new ArrayList<>(
+                getRequestLocationUpdateListeners());
         for (LocationListener locationUpdateListener : locationUpdateListeners) {
             if (isEnabled) {
                 locationUpdateListener.onProviderEnabled(provider);
@@ -146,9 +165,10 @@ public class LostShadowLocationManager {
         final Intent intent = new Intent();
         intent.putExtra(LocationManager.KEY_PROVIDER_ENABLED, isEnabled);
         ShadowApplication.getInstance().sendBroadcast(intent);
-        Set<PendingIntent> requestLocationUdpatePendingIntentSet = requestLocationUdpateCriteriaPendingIntents
-                .keySet();
-        for (PendingIntent requestLocationUdpatePendingIntent : requestLocationUdpatePendingIntentSet) {
+        Set<PendingIntent> requestLocationUdpatePendingIntentSet =
+                requestLocationUdpateCriteriaPendingIntents.keySet();
+        for (PendingIntent requestLocationUdpatePendingIntent :
+                requestLocationUdpatePendingIntentSet) {
             try {
                 requestLocationUdpatePendingIntent.send();
             } catch (PendingIntent.CanceledException e) {
@@ -228,15 +248,18 @@ public class LostShadowLocationManager {
         }
         // TODO: these conditions are incomplete
         for (String provider : providers) {
-            if (provider.equals(LocationManager.NETWORK_PROVIDER) && (accuracy == Criteria.ACCURACY_COARSE || powerRequirement == Criteria.POWER_LOW)) {
+            if (provider.equals(LocationManager.NETWORK_PROVIDER) && (accuracy ==
+                    Criteria.ACCURACY_COARSE || powerRequirement == Criteria.POWER_LOW)) {
                 return provider;
-            } else if (provider.equals(LocationManager.GPS_PROVIDER) && accuracy == Criteria.ACCURACY_FINE && powerRequirement != Criteria.POWER_LOW) {
+            } else if (provider.equals(LocationManager.GPS_PROVIDER) && accuracy ==
+                    Criteria.ACCURACY_FINE && powerRequirement != Criteria.POWER_LOW) {
                 return provider;
             }
         }
 
-        // No enabled provider found with the desired criteria, then return the the first registered provider(?)
-        return providers.isEmpty()? null : providers.get(0);
+        // No enabled provider found with the desired criteria, then return the the first registered
+        // provider(?)
+        return providers.isEmpty() ? null : providers.get(0);
     }
 
     private String getBestProviderWithNoCriteria(boolean enabled) {
@@ -255,11 +278,13 @@ public class LostShadowLocationManager {
     }
 
     @Implementation
-    public void requestLocationUpdates(String provider, long minTime, float minDistance, LocationListener listener) {
+    public void requestLocationUpdates(String provider, long minTime, float minDistance,
+                                       LocationListener listener) {
         addLocationListener(provider, listener, minTime, minDistance);
     }
 
-    private void addLocationListener(String provider, LocationListener listener, long minTime, float minDistance) {
+    private void addLocationListener(String provider, LocationListener listener, long minTime,
+                                     float minDistance) {
         List<ListenerRegistration> providerListeners = locationListeners.get(provider);
         if (providerListeners == null) {
             providerListeners = new ArrayList<>();
@@ -278,13 +303,14 @@ public class LostShadowLocationManager {
     }
 
     @Implementation
-    public void requestLocationUpdates(String provider, long minTime, float minDistance, LocationListener listener,
-                                       Looper looper) {
+    public void requestLocationUpdates(String provider, long minTime, float minDistance,
+                                       LocationListener listener, Looper looper) {
         addLocationListener(provider, listener, minTime, minDistance);
     }
 
     @Implementation
-    public void requestLocationUpdates(long minTime, float minDistance, Criteria criteria, PendingIntent pendingIntent) {
+    public void requestLocationUpdates(long minTime, float minDistance, Criteria criteria,
+                                       PendingIntent pendingIntent) {
         if (pendingIntent == null) {
             throw new IllegalStateException("Intent must not be null");
         }
@@ -317,7 +343,7 @@ public class LostShadowLocationManager {
             List<ListenerRegistration> listenerRegistrations = entry.getValue();
             for (int i = listenerRegistrations.size() - 1; i >= 0; i--) {
                 LocationListener listener = listenerRegistrations.get(i).listener;
-                if(removedLocationListeners.contains(listener)) {
+                if (removedLocationListeners.contains(listener)) {
                     listenerRegistrations.remove(i);
                 }
             }
@@ -326,8 +352,12 @@ public class LostShadowLocationManager {
 
     @Implementation
     public void removeUpdates(PendingIntent pendingIntent) {
-        while (requestLocationUdpateCriteriaPendingIntents.remove(pendingIntent) != null);
-        while (requestLocationUdpateProviderPendingIntents.remove(pendingIntent) != null);
+        while (requestLocationUdpateCriteriaPendingIntents.containsKey(pendingIntent)) {
+            requestLocationUdpateCriteriaPendingIntents.remove(pendingIntent);
+        }
+        while (requestLocationUdpateProviderPendingIntents.containsKey(pendingIntent)) {
+            requestLocationUdpateProviderPendingIntents.remove(pendingIntent);
+        }
     }
 
     public boolean hasGpsStatusListener(GpsStatus.Listener listener) {
@@ -338,7 +368,8 @@ public class LostShadowLocationManager {
      * Non-Android accessor.
      *
      * <p>
-     * Gets the criteria value used in the last call to {@link #getBestProvider(android.location.Criteria, boolean)}
+     * Gets the criteria value used in the last call to {@link #getBestProvider(
+     * android.location.Criteria, boolean)}
      *
      * @return the criteria used to find the best provider
      */
@@ -350,7 +381,8 @@ public class LostShadowLocationManager {
      * Non-Android accessor.
      *
      * <p>
-     * Gets the enabled value used in the last call to {@link #getBestProvider(android.location.Criteria, boolean)}
+     * Gets the enabled value used in the last call to {@link #getBestProvider(
+     * android.location.Criteria, boolean)}
      *
      * @return the enabled value used to find the best provider
      */
@@ -359,20 +391,24 @@ public class LostShadowLocationManager {
     }
 
     /**
-     * Sets the value to return from {@link #getBestProvider(android.location.Criteria, boolean)} for the given
+     * Sets the value to return from {@link #getBestProvider(android.location.Criteria, boolean)}
+     * for the given
      * {@code provider}
      *
      * @param provider name of the provider who should be considered best
      * @param enabled Enabled
      * @param criteria List of criteria
      * @throws Exception if provider is not known
-     * @return false If provider is not enabled but it is supposed to be set as the best enabled provider don't set it, otherwise true
+     * @return false If provider is not enabled but it is supposed to be set as the best enabled
+     * provider don't set it, otherwise true
      */
-    public boolean setBestProvider(String provider, boolean enabled, List<Criteria> criteria) throws Exception {
+    public boolean setBestProvider(String provider, boolean enabled, List<Criteria> criteria)
+            throws Exception {
         if (!getAllProviders().contains(provider)) {
             throw new IllegalStateException("Best provider is not a known provider");
         }
-        // If provider is not enabled but it is supposed to be set as the best enabled provider don't set it.
+        // If provider is not enabled but it is supposed to be set as the best enabled provider
+        // don't set it.
         for (String prvdr : providersEnabled.keySet()) {
             if (provider.equals(prvdr) && providersEnabled.get(prvdr).enabled != enabled) {
                 return false;
@@ -411,7 +447,8 @@ public class LostShadowLocationManager {
     }
 
     /**
-     * Sets the value to return from {@link #getLastKnownLocation(String)} for the given {@code provider}
+     * Sets the value to return from {@link #getLastKnownLocation(String)} for the given {@code
+     * provider}
      *
      * @param provider
      *            name of the provider whose location to set
@@ -445,14 +482,19 @@ public class LostShadowLocationManager {
 
         List<ListenerRegistration> providerListeners = locationListeners.get(
                 location.getProvider());
-        if (providerListeners == null) return;
+        if (providerListeners == null) {
+            return;
+        }
 
         for (ListenerRegistration listenerReg : providerListeners) {
-            if(listenerReg.lastSeenLocation != null && location != null) {
+            if (listenerReg.lastSeenLocation != null && location != null) {
                 float distanceChange = distanceBetween(location, listenerReg.lastSeenLocation);
                 boolean withinMinDistance = distanceChange < listenerReg.minDistance;
-                boolean exceededMinTime = location.getTime() - listenerReg.lastSeenTime > listenerReg.minTime;
-                if (withinMinDistance || !exceededMinTime) continue;
+                boolean exceededMinTime = location.getTime() - listenerReg.lastSeenTime >
+                        listenerReg.minTime;
+                if (withinMinDistance || !exceededMinTime) {
+                    continue;
+                }
             }
             listenerReg.lastSeenLocation = copyOf(location);
             listenerReg.lastSeenTime = location == null ? 0 : location.getTime();
@@ -462,7 +504,9 @@ public class LostShadowLocationManager {
     }
 
     private Location copyOf(Location location) {
-        if (location == null) return null;
+        if (location == null) {
+            return null;
+        }
         Location copy = new Location(location);
         copy.setAccuracy(location.getAccuracy());
         copy.setAltitude(location.getAltitude());
@@ -478,16 +522,18 @@ public class LostShadowLocationManager {
 
     /**
      * Returns the distance between the two locations in meters.
-     * Adapted from: http://stackoverflow.com/questions/837872/calculate-distance-in-meters-when-you-know-longitude-and-latitude-in-java
+     * Adapted from: http://stackoverflow.com/questions/837872/calculate-distance-in-meters-when-
+     * you-know-longitude-and-latitude-in-java
      */
     private static float distanceBetween(Location location1, Location location2) {
         double earthRadius = 3958.75;
         double latDifference = Math.toRadians(location2.getLatitude() - location1.getLatitude());
         double lonDifference = Math.toRadians(location2.getLongitude() - location2.getLongitude());
-        double a = Math.sin(latDifference/2) * Math.sin(latDifference/2) +
-                Math.cos(Math.toRadians(location1.getLatitude())) * Math.cos(Math.toRadians(location2.getLatitude())) *
-                        Math.sin(lonDifference/2) * Math.sin(lonDifference/2);
-        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+        double a = Math.sin(latDifference / 2) * Math.sin(latDifference / 2) +
+                Math.cos(Math.toRadians(location1.getLatitude())) * Math.cos(Math.toRadians(
+                        location2.getLatitude())) *
+                        Math.sin(lonDifference / 2) * Math.sin(lonDifference / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
         double dist = Math.abs(earthRadius * c);
 
         int meterConversion = 1609;
@@ -520,7 +566,7 @@ public class LostShadowLocationManager {
     public void requestSingleUpdate(String provider, LocationListener listener, Looper looper) {
     }
 
-    final private class LocationProviderEntry implements Map.Entry<Boolean, List<Criteria>> {
+    private final class LocationProviderEntry implements Map.Entry<Boolean, List<Criteria>> {
         private Boolean enabled;
         private List<Criteria> criteria;
 

--- a/lost/src/test/java/com/mapzen/android/lost/shadows/LostShadowLocationManager.java
+++ b/lost/src/test/java/com/mapzen/android/lost/shadows/LostShadowLocationManager.java
@@ -1,0 +1,511 @@
+package com.mapzen.android.lost.shadows;
+
+
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.location.Criteria;
+import android.location.GpsStatus;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Looper;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowApplication;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Shadow that pastes in existing Robolectric class and adds missing method:
+ * {@link LocationManager#requestSingleUpdate(String provider, LocationListener listener,
+ * Looper looper)}
+ */
+@Implements(LocationManager.class)
+public class LostShadowLocationManager {
+
+    private final Map<String, LocationProviderEntry> providersEnabled = new LinkedHashMap<>();
+    private final Map<String, Location> lastKnownLocations = new HashMap<>();
+    private final Map<PendingIntent, Criteria> requestLocationUdpateCriteriaPendingIntents = new HashMap<>();
+    private final Map<PendingIntent, String> requestLocationUdpateProviderPendingIntents = new HashMap<>();
+    private final ArrayList<LocationListener> removedLocationListeners = new ArrayList<>();
+
+    private final ArrayList<GpsStatus.Listener> gpsStatusListeners = new ArrayList<>();
+    private Criteria lastBestProviderCriteria;
+    private boolean lastBestProviderEnabled;
+    private String bestEnabledProvider, bestDisabledProvider;
+
+    /** Location listeners along with metadata on when they should be fired. */
+    private static final class ListenerRegistration {
+        final long minTime;
+        final float minDistance;
+        final LocationListener listener;
+        final String provider;
+        Location lastSeenLocation;
+        long lastSeenTime;
+
+        ListenerRegistration(String provider, long minTime, float minDistance, Location locationAtCreation,
+                             LocationListener listener) {
+            this.provider = provider;
+            this.minTime = minTime;
+            this.minDistance = minDistance;
+            this.lastSeenTime = locationAtCreation == null ? 0 : locationAtCreation.getTime();
+            this.lastSeenLocation = locationAtCreation;
+            this.listener = listener;
+        }
+    }
+
+    /** Mapped by provider. */
+    private final Map<String, List<ListenerRegistration>> locationListeners =
+            new HashMap<>();
+
+    @Implementation
+    public boolean isProviderEnabled(String provider) {
+        LocationProviderEntry map = providersEnabled.get(provider);
+        if (map != null) {
+            Boolean isEnabled = map.getKey();
+            return isEnabled == null ? true : isEnabled;
+        }
+        return false;
+    }
+
+    @Implementation
+    public List<String> getAllProviders() {
+        Set<String> allKnownProviders = new LinkedHashSet<>(providersEnabled.keySet());
+        allKnownProviders.add(LocationManager.GPS_PROVIDER);
+        allKnownProviders.add(LocationManager.NETWORK_PROVIDER);
+        allKnownProviders.add(LocationManager.PASSIVE_PROVIDER);
+
+        return new ArrayList<>(allKnownProviders);
+    }
+
+    /**
+     * Sets the value to return from {@link #isProviderEnabled(String)} for the given {@code provider}
+     *
+     * @param provider
+     *            name of the provider whose status to set
+     * @param isEnabled
+     *            whether that provider should appear enabled
+     */
+    public void setProviderEnabled(String provider, boolean isEnabled) {
+        setProviderEnabled(provider, isEnabled, null);
+    }
+
+    public void setProviderEnabled(String provider, boolean isEnabled, List<Criteria> criteria) {
+        LocationProviderEntry providerEntry = providersEnabled.get(provider);
+        if (providerEntry == null) {
+            providerEntry = new LocationProviderEntry();
+        }
+        providerEntry.enabled = isEnabled;
+        providerEntry.criteria = criteria;
+        providersEnabled.put(provider, providerEntry);
+        List<LocationListener> locationUpdateListeners = new ArrayList<>(getRequestLocationUpdateListeners());
+        for (LocationListener locationUpdateListener : locationUpdateListeners) {
+            if (isEnabled) {
+                locationUpdateListener.onProviderEnabled(provider);
+            } else {
+                locationUpdateListener.onProviderDisabled(provider);
+            }
+        }
+        // Send intent to notify about provider status
+        final Intent intent = new Intent();
+        intent.putExtra(LocationManager.KEY_PROVIDER_ENABLED, isEnabled);
+        ShadowApplication.getInstance().sendBroadcast(intent);
+        Set<PendingIntent> requestLocationUdpatePendingIntentSet = requestLocationUdpateCriteriaPendingIntents
+                .keySet();
+        for (PendingIntent requestLocationUdpatePendingIntent : requestLocationUdpatePendingIntentSet) {
+            try {
+                requestLocationUdpatePendingIntent.send();
+            } catch (PendingIntent.CanceledException e) {
+                requestLocationUdpateCriteriaPendingIntents
+                        .remove(requestLocationUdpatePendingIntent);
+            }
+        }
+        // if this provider gets disabled and it was the best active provider, then it's not anymore
+        if (provider.equals(bestEnabledProvider) && !isEnabled) {
+            bestEnabledProvider = null;
+        }
+    }
+
+    @Implementation
+    public List<String> getProviders(boolean enabledOnly) {
+        ArrayList<String> enabledProviders = new ArrayList<>();
+        for (String provider : getAllProviders()) {
+            if (!enabledOnly || providersEnabled.get(provider) != null) {
+                enabledProviders.add(provider);
+            }
+        }
+        return enabledProviders;
+    }
+
+    @Implementation
+    public Location getLastKnownLocation(String provider) {
+        return lastKnownLocations.get(provider);
+    }
+
+    @Implementation
+    public boolean addGpsStatusListener(GpsStatus.Listener listener) {
+        if (!gpsStatusListeners.contains(listener)) {
+            gpsStatusListeners.add(listener);
+        }
+        return true;
+    }
+
+    @Implementation
+    public void removeGpsStatusListener(GpsStatus.Listener listener) {
+        gpsStatusListeners.remove(listener);
+    }
+
+    @Implementation
+    public String getBestProvider(Criteria criteria, boolean enabled) {
+        lastBestProviderCriteria = criteria;
+        lastBestProviderEnabled = enabled;
+
+        if (criteria == null) {
+            return getBestProviderWithNoCriteria(enabled);
+        }
+
+        return getBestProviderWithCriteria(criteria, enabled);
+    }
+
+    private String getBestProviderWithCriteria(Criteria criteria, boolean enabled) {
+        List<String> providers = getProviders(enabled);
+        int powerRequirement = criteria.getPowerRequirement();
+        int accuracy = criteria.getAccuracy();
+        for (String provider : providers) {
+            LocationProviderEntry locationProviderEntry = providersEnabled.get(provider);
+            if (locationProviderEntry == null) {
+                continue;
+            }
+            List<Criteria> criteriaList = locationProviderEntry.getValue();
+            if (criteriaList == null) {
+                continue;
+            }
+            for (Criteria criteriaListItem : criteriaList) {
+                if (criteria.equals(criteriaListItem)) {
+                    return provider;
+                } else if (criteriaListItem.getAccuracy() == accuracy) {
+                    return provider;
+                } else if (criteriaListItem.getPowerRequirement() == powerRequirement) {
+                    return provider;
+                }
+            }
+        }
+        // TODO: these conditions are incomplete
+        for (String provider : providers) {
+            if (provider.equals(LocationManager.NETWORK_PROVIDER) && (accuracy == Criteria.ACCURACY_COARSE || powerRequirement == Criteria.POWER_LOW)) {
+                return provider;
+            } else if (provider.equals(LocationManager.GPS_PROVIDER) && accuracy == Criteria.ACCURACY_FINE && powerRequirement != Criteria.POWER_LOW) {
+                return provider;
+            }
+        }
+
+        // No enabled provider found with the desired criteria, then return the the first registered provider(?)
+        return providers.isEmpty()? null : providers.get(0);
+    }
+
+    private String getBestProviderWithNoCriteria(boolean enabled) {
+        List<String> providers = getProviders(enabled);
+
+        if (enabled && bestEnabledProvider != null) {
+            return bestEnabledProvider;
+        } else if (bestDisabledProvider != null) {
+            return bestDisabledProvider;
+        } else if (providers.contains(LocationManager.GPS_PROVIDER)) {
+            return LocationManager.GPS_PROVIDER;
+        } else if (providers.contains(LocationManager.NETWORK_PROVIDER)) {
+            return LocationManager.NETWORK_PROVIDER;
+        }
+        return null;
+    }
+
+    @Implementation
+    public void requestLocationUpdates(String provider, long minTime, float minDistance, LocationListener listener) {
+        addLocationListener(provider, listener, minTime, minDistance);
+    }
+
+    private void addLocationListener(String provider, LocationListener listener, long minTime, float minDistance) {
+        List<ListenerRegistration> providerListeners = locationListeners.get(provider);
+        if (providerListeners == null) {
+            providerListeners = new ArrayList<>();
+            locationListeners.put(provider, providerListeners);
+        }
+        providerListeners.add(new ListenerRegistration(provider,
+                minTime, minDistance, copyOf(getLastKnownLocation(provider)), listener));
+
+    }
+
+    @Implementation
+    public void requestLocationUpdates(String provider, long minTime, float minDistance, LocationListener listener,
+                                       Looper looper) {
+        addLocationListener(provider, listener, minTime, minDistance);
+    }
+
+    @Implementation
+    public void requestLocationUpdates(long minTime, float minDistance, Criteria criteria, PendingIntent pendingIntent) {
+        if (pendingIntent == null) {
+            throw new IllegalStateException("Intent must not be null");
+        }
+        if (getBestProvider(criteria, true) == null) {
+            throw new IllegalArgumentException("no providers found for criteria");
+        }
+        requestLocationUdpateCriteriaPendingIntents.put(pendingIntent, criteria);
+    }
+
+    @Implementation
+    public void requestLocationUpdates(String provider, long minTime, float minDistance,
+                                       PendingIntent pendingIntent) {
+        if (pendingIntent == null) {
+            throw new IllegalStateException("Intent must not be null");
+        }
+        if (!providersEnabled.containsKey(provider)) {
+            throw new IllegalArgumentException("no providers found");
+        }
+
+        requestLocationUdpateProviderPendingIntents.put(pendingIntent, provider);
+    }
+
+    @Implementation
+    public void removeUpdates(LocationListener listener) {
+        removedLocationListeners.add(listener);
+    }
+
+    private void cleanupRemovedLocationListeners() {
+        for (Map.Entry<String, List<ListenerRegistration>> entry : locationListeners.entrySet()) {
+            List<ListenerRegistration> listenerRegistrations = entry.getValue();
+            for (int i = listenerRegistrations.size() - 1; i >= 0; i--) {
+                LocationListener listener = listenerRegistrations.get(i).listener;
+                if(removedLocationListeners.contains(listener)) {
+                    listenerRegistrations.remove(i);
+                }
+            }
+        }
+    }
+
+    @Implementation
+    public void removeUpdates(PendingIntent pendingIntent) {
+        while (requestLocationUdpateCriteriaPendingIntents.remove(pendingIntent) != null);
+        while (requestLocationUdpateProviderPendingIntents.remove(pendingIntent) != null);
+    }
+
+    public boolean hasGpsStatusListener(GpsStatus.Listener listener) {
+        return gpsStatusListeners.contains(listener);
+    }
+
+    /**
+     * Non-Android accessor.
+     *
+     * <p>
+     * Gets the criteria value used in the last call to {@link #getBestProvider(android.location.Criteria, boolean)}
+     *
+     * @return the criteria used to find the best provider
+     */
+    public Criteria getLastBestProviderCriteria() {
+        return lastBestProviderCriteria;
+    }
+
+    /**
+     * Non-Android accessor.
+     *
+     * <p>
+     * Gets the enabled value used in the last call to {@link #getBestProvider(android.location.Criteria, boolean)}
+     *
+     * @return the enabled value used to find the best provider
+     */
+    public boolean getLastBestProviderEnabledOnly() {
+        return lastBestProviderEnabled;
+    }
+
+    /**
+     * Sets the value to return from {@link #getBestProvider(android.location.Criteria, boolean)} for the given
+     * {@code provider}
+     *
+     * @param provider name of the provider who should be considered best
+     * @param enabled Enabled
+     * @param criteria List of criteria
+     * @throws Exception if provider is not known
+     * @return false If provider is not enabled but it is supposed to be set as the best enabled provider don't set it, otherwise true
+     */
+    public boolean setBestProvider(String provider, boolean enabled, List<Criteria> criteria) throws Exception {
+        if (!getAllProviders().contains(provider)) {
+            throw new IllegalStateException("Best provider is not a known provider");
+        }
+        // If provider is not enabled but it is supposed to be set as the best enabled provider don't set it.
+        for (String prvdr : providersEnabled.keySet()) {
+            if (provider.equals(prvdr) && providersEnabled.get(prvdr).enabled != enabled) {
+                return false;
+            }
+        }
+
+        if (enabled) {
+            bestEnabledProvider = provider;
+            if (provider.equals(bestDisabledProvider)) {
+                bestDisabledProvider = null;
+            }
+        } else {
+            bestDisabledProvider = provider;
+            if (provider.equals(bestEnabledProvider)) {
+                bestEnabledProvider = null;
+            }
+        }
+        if (criteria == null) {
+            return true;
+        }
+        LocationProviderEntry entry;
+        if (!providersEnabled.containsKey(provider)) {
+            entry = new LocationProviderEntry();
+            entry.enabled = enabled;
+            entry.criteria = criteria;
+        } else {
+            entry = providersEnabled.get(provider);
+        }
+        providersEnabled.put(provider, entry);
+
+        return true;
+    }
+
+    public boolean setBestProvider(String provider, boolean enabled) throws Exception {
+        return setBestProvider(provider, enabled, null);
+    }
+
+    /**
+     * Sets the value to return from {@link #getLastKnownLocation(String)} for the given {@code provider}
+     *
+     * @param provider
+     *            name of the provider whose location to set
+     * @param location
+     *            the last known location for the provider
+     */
+    public void setLastKnownLocation(String provider, Location location) {
+        lastKnownLocations.put(provider, location);
+    }
+
+    /**
+     * Non-Android accessor.
+     *
+     * @return lastRequestedLocationUpdatesLocationListener
+     */
+    public List<LocationListener> getRequestLocationUpdateListeners() {
+        cleanupRemovedLocationListeners();
+        List<LocationListener> all = new ArrayList<>();
+        for (Map.Entry<String, List<ListenerRegistration>> entry : locationListeners.entrySet()) {
+            for (ListenerRegistration reg : entry.getValue()) {
+                all.add(reg.listener);
+            }
+        }
+
+        return all;
+    }
+
+    public void simulateLocation(Location location) {
+        cleanupRemovedLocationListeners();
+        setLastKnownLocation(location.getProvider(), location);
+
+        List<ListenerRegistration> providerListeners = locationListeners.get(
+                location.getProvider());
+        if (providerListeners == null) return;
+
+        for (ListenerRegistration listenerReg : providerListeners) {
+            if(listenerReg.lastSeenLocation != null && location != null) {
+                float distanceChange = distanceBetween(location, listenerReg.lastSeenLocation);
+                boolean withinMinDistance = distanceChange < listenerReg.minDistance;
+                boolean exceededMinTime = location.getTime() - listenerReg.lastSeenTime > listenerReg.minTime;
+                if (withinMinDistance || !exceededMinTime) continue;
+            }
+            listenerReg.lastSeenLocation = copyOf(location);
+            listenerReg.lastSeenTime = location == null ? 0 : location.getTime();
+            listenerReg.listener.onLocationChanged(copyOf(location));
+        }
+        cleanupRemovedLocationListeners();
+    }
+
+    private Location copyOf(Location location) {
+        if (location == null) return null;
+        Location copy = new Location(location);
+        copy.setAccuracy(location.getAccuracy());
+        copy.setAltitude(location.getAltitude());
+        copy.setBearing(location.getBearing());
+        copy.setExtras(location.getExtras());
+        copy.setLatitude(location.getLatitude());
+        copy.setLongitude(location.getLongitude());
+        copy.setProvider(location.getProvider());
+        copy.setSpeed(location.getSpeed());
+        copy.setTime(location.getTime());
+        return copy;
+    }
+
+    /**
+     * Returns the distance between the two locations in meters.
+     * Adapted from: http://stackoverflow.com/questions/837872/calculate-distance-in-meters-when-you-know-longitude-and-latitude-in-java
+     */
+    private static float distanceBetween(Location location1, Location location2) {
+        double earthRadius = 3958.75;
+        double latDifference = Math.toRadians(location2.getLatitude() - location1.getLatitude());
+        double lonDifference = Math.toRadians(location2.getLongitude() - location2.getLongitude());
+        double a = Math.sin(latDifference/2) * Math.sin(latDifference/2) +
+                Math.cos(Math.toRadians(location1.getLatitude())) * Math.cos(Math.toRadians(location2.getLatitude())) *
+                        Math.sin(lonDifference/2) * Math.sin(lonDifference/2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+        double dist = Math.abs(earthRadius * c);
+
+        int meterConversion = 1609;
+
+        return new Float(dist * meterConversion);
+    }
+
+    public Map<PendingIntent, Criteria> getRequestLocationUdpateCriteriaPendingIntents() {
+        return requestLocationUdpateCriteriaPendingIntents;
+    }
+
+    public Map<PendingIntent, String> getRequestLocationUdpateProviderPendingIntents() {
+        return requestLocationUdpateProviderPendingIntents;
+    }
+
+    public Collection<String> getProvidersForListener(LocationListener listener) {
+        cleanupRemovedLocationListeners();
+        Set<String> providers = new HashSet<>();
+        for (List<ListenerRegistration> listenerRegistrations : locationListeners.values()) {
+            for (ListenerRegistration listenerRegistration : listenerRegistrations) {
+                if (listenerRegistration.listener == listener) {
+                    providers.add(listenerRegistration.provider);
+                }
+            }
+        }
+        return providers;
+    }
+
+    @Implementation
+    public void requestSingleUpdate(String provider, LocationListener listener, Looper looper) {
+    }
+
+    final private class LocationProviderEntry implements Map.Entry<Boolean, List<Criteria>> {
+        private Boolean enabled;
+        private List<Criteria> criteria;
+
+        @Override
+        public Boolean getKey() {
+            return enabled;
+        }
+
+        @Override
+        public List<Criteria> getValue() {
+            return criteria;
+        }
+
+        @Override
+        public List<Criteria> setValue(List<Criteria> criteria) {
+            List<Criteria> oldCriteria = this.criteria;
+            this.criteria = criteria;
+            return oldCriteria;
+        }
+    }
+
+}


### PR DESCRIPTION
### Overview
This PR changes the underlying mechanism that Lost uses to notify of providers enabled/disabled from a `LocationListener` to a `ContentObserver` on the system location provider setting.

### Proposed Changes
`FusionEngine` no longer does anything with its provider changed `LocationListener` methods and instead uses `LocationProviderChangedHandler` to receive notifications of providers enabled & disabled. The `LocationProviderChangedHandler` handles setting up a `ContentObserver` to listen to changes to `Settings.System.LOCATION_PROVIDERS_ALLOWED`.

Closes #123 