### PR TITLE
Remove connection callbacks when client disconnected

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -165,11 +165,11 @@ public class FusedLocationProviderApiImpl
     return service;
   }
 
-  public void removeConnectionCallbacks(LostApiClient.ConnectionCallbacks callbacks) {
+  void removeConnectionCallbacks(LostApiClient.ConnectionCallbacks callbacks) {
     serviceConnectionManager.removeCallbacks(callbacks);
   }
 
-  public FusedLocationServiceConnectionManager getServiceConnectionManager() {
+  FusedLocationServiceConnectionManager getServiceConnectionManager() {
     return serviceConnectionManager;
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -164,4 +164,12 @@ public class FusedLocationProviderApiImpl
   public FusedLocationProviderService getService() {
     return service;
   }
+
+  public void removeConnectionCallbacks(LostApiClient.ConnectionCallbacks callbacks) {
+    serviceConnectionManager.removeCallbacks(callbacks);
+  }
+
+  public FusedLocationServiceConnectionManager getServiceConnectionManager() {
+    return serviceConnectionManager;
+  }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
@@ -38,6 +38,12 @@ public class FusedLocationServiceConnectionManager {
     }
   }
 
+  public void removeCallbacks(ConnectionCallbacks callbacks) {
+    if (callbacks != null) {
+      connectionCallbacks.remove(callbacks);
+    }
+  }
+
   public boolean isConnected() {
     return connectState == ConnectState.CONNECTED;
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
@@ -48,6 +48,8 @@ public class LostApiClientImpl implements LostApiClient {
   }
 
   @Override public void disconnect() {
+    getFusedLocationProviderApiImpl().removeConnectionCallbacks(connectionCallbacks);
+
     clientManager.removeClient(this);
     if (clientManager.numberOfClients() > 0) {
       return;

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -1,5 +1,9 @@
 package com.mapzen.android.lost.internal;
 
+import android.content.ComponentName;
+import android.location.Location;
+import android.location.LocationManager;
+
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LocationServices;
@@ -12,10 +16,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
-
-import android.content.ComponentName;
-import android.location.Location;
-import android.location.LocationManager;
 
 import static android.content.Context.LOCATION_SERVICE;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -168,6 +168,16 @@ public class LostApiClientImplTest {
     client.connect();
     client.disconnect();
     assertThat(LocationServices.SettingsApi).isNotNull();
+  }
+
+  @Test public void disconnect_shouldRemoveConnectionCallbacks() {
+    client.connect();
+    client.disconnect();
+    FusedLocationProviderApiImpl fusedLocationProviderApi = (FusedLocationProviderApiImpl)
+            LocationServices.FusedLocationApi;
+    FusedLocationServiceConnectionManager serviceConnectionManager =
+            fusedLocationProviderApi.getServiceConnectionManager();
+    assertThat(serviceConnectionManager.connectionCallbacks.size()).isEqualTo(0);
   }
 
   @Test

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -1,9 +1,5 @@
 package com.mapzen.android.lost.internal;
 
-import android.content.ComponentName;
-import android.location.Location;
-import android.location.LocationManager;
-
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LocationServices;
@@ -16,6 +12,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
+
+import android.content.ComponentName;
+import android.location.Location;
+import android.location.LocationManager;
 
 import static android.content.Context.LOCATION_SERVICE;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -34,12 +34,11 @@ public class LostApiClientImplTest {
     callbacks = new TestConnectionCallbacks();
     client = new LostApiClientImpl(application, callbacks, new TestClientManager());
 
-    FusedLocationProviderService.FusedLocationProviderBinder stubBinder = mock(
-        FusedLocationProviderService.FusedLocationProviderBinder.class);
+    FusedLocationProviderService.FusedLocationProviderBinder stubBinder =
+        mock(FusedLocationProviderService.FusedLocationProviderBinder.class);
     when(stubBinder.getService()).thenReturn(mock(FusedLocationProviderService.class));
     shadowOf(application).setComponentNameAndServiceForBindService(
         new ComponentName("com.mapzen.lost", "FusedLocationProviderService"), stubBinder);
-
   }
 
   @After public void tearDown() throws Exception {
@@ -65,8 +64,7 @@ public class LostApiClientImplTest {
     assertThat(settingsApi.isConnected()).isTrue();
   }
 
-  @Test public void connect_shouldBeConnectedWhenConnectionCallbackInvoked()
-      throws Exception {
+  @Test public void connect_shouldBeConnectedWhenConnectionCallbackInvoked() throws Exception {
     callbacks.setLostClient(client);
     client.connect();
     assertThat(callbacks.isClientConnectedOnConnect()).isTrue();
@@ -76,8 +74,8 @@ public class LostApiClientImplTest {
       throws Exception {
     client.connect();
     TestConnectionCallbacks callbacks = new TestConnectionCallbacks();
-    LostApiClient anotherClient = new LostApiClientImpl(application, callbacks,
-        new TestClientManager());
+    LostApiClient anotherClient =
+        new LostApiClientImpl(application, callbacks, new TestClientManager());
     callbacks.setLostClient(anotherClient);
     anotherClient.connect();
     assertThat(callbacks.isClientConnectedOnConnect()).isTrue();
@@ -144,8 +142,8 @@ public class LostApiClientImplTest {
 
   @Test public void disconnect_multipleClients_shouldNotRemoveFusedLocationProviderApiImpl()
       throws Exception {
-    LostApiClient anotherClient = new LostApiClientImpl(application, callbacks,
-        new TestClientManager());
+    LostApiClient anotherClient =
+        new LostApiClientImpl(application, callbacks, new TestClientManager());
     anotherClient.connect();
     client.connect();
     client.disconnect();
@@ -153,8 +151,8 @@ public class LostApiClientImplTest {
   }
 
   @Test public void disconnect_multipleClients_shouldNotRemoveGeofencingApiImpl() throws Exception {
-    LostApiClient anotherClient = new LostApiClientImpl(application, callbacks,
-        new TestClientManager());
+    LostApiClient anotherClient =
+        new LostApiClientImpl(application, callbacks, new TestClientManager());
     anotherClient.connect();
     client.connect();
     client.disconnect();
@@ -162,8 +160,8 @@ public class LostApiClientImplTest {
   }
 
   @Test public void disconnect_multipleClients_shouldNotRemoveSettingsApiImpl() throws Exception {
-    LostApiClient anotherClient = new LostApiClientImpl(application, callbacks,
-        new TestClientManager());
+    LostApiClient anotherClient =
+        new LostApiClientImpl(application, callbacks, new TestClientManager());
     anotherClient.connect();
     client.connect();
     client.disconnect();
@@ -173,15 +171,14 @@ public class LostApiClientImplTest {
   @Test public void disconnect_shouldRemoveConnectionCallbacks() {
     client.connect();
     client.disconnect();
-    FusedLocationProviderApiImpl fusedLocationProviderApi = (FusedLocationProviderApiImpl)
-            LocationServices.FusedLocationApi;
+    FusedLocationProviderApiImpl fusedLocationProviderApi =
+        (FusedLocationProviderApiImpl) LocationServices.FusedLocationApi;
     FusedLocationServiceConnectionManager serviceConnectionManager =
-            fusedLocationProviderApi.getServiceConnectionManager();
+        fusedLocationProviderApi.getServiceConnectionManager();
     assertThat(serviceConnectionManager.connectionCallbacks.size()).isEqualTo(0);
   }
 
-  @Test
-  public void isConnected_shouldReturnFalseBeforeConnected() throws Exception {
+  @Test public void isConnected_shouldReturnFalseBeforeConnected() throws Exception {
     assertThat(client.isConnected()).isFalse();
   }
 
@@ -196,14 +193,13 @@ public class LostApiClientImplTest {
     assertThat(client.isConnected()).isFalse();
   }
 
-  @Test public void isConnected_multipleClients_shouldReturnFalseAfterDisconnected() throws
-      Exception {
-    LostApiClient anotherClient = new LostApiClientImpl(application, callbacks,
-        new TestClientManager());
+  @Test public void isConnected_multipleClients_shouldReturnFalseAfterDisconnected()
+      throws Exception {
+    LostApiClient anotherClient =
+        new LostApiClientImpl(application, callbacks, new TestClientManager());
     anotherClient.connect();
     client.connect();
     client.disconnect();
     assertThat(client.isConnected()).isFalse();
   }
-
 }


### PR DESCRIPTION
### Overview
This PR fixes a bug which caused `ConnectionCallbacks#onConnected` to be called multiple times when the lifecycle of the `LostApiClient` was tied to the `Activity` lifecycle.

### Proposed Changes
This adds a call to remove the `LostApiClient` `ConnectionCallback` when the client is disconnected, making the management of callbacks symmetrical. Previously, they were only added when the client was connected.

Closes #138 
