### PR TITLE
Report last known location when engine enabled

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
@@ -103,13 +103,31 @@ public class FusionEngine extends LocationEngine implements LocationListener {
       }
     }
 
-    if (networkInterval < Long.MAX_VALUE) {
-      enableNetwork(networkInterval);
-      checkLastKnownNetwork();
-    }
+    boolean checkGps = false;
     if (gpsInterval < Long.MAX_VALUE) {
       enableGps(gpsInterval);
-      checkLastKnownGps();
+      checkGps = true;
+    }
+    if (networkInterval < Long.MAX_VALUE) {
+      enableNetwork(networkInterval);
+      if (checkGps) {
+        Location lastGps = locationManager.getLastKnownLocation(GPS_PROVIDER);
+        Location lastNetwork = locationManager.getLastKnownLocation(NETWORK_PROVIDER);
+        if (lastGps != null && lastNetwork != null) {
+          boolean useGps = isBetterThan(lastGps, lastNetwork);
+          if (useGps) {
+            checkLastKnownGps();
+          } else {
+            checkLastKnownNetwork();
+          }
+        } else if (lastGps != null) {
+          checkLastKnownGps();
+        } else {
+          checkLastKnownNetwork();
+        }
+      } else {
+        checkLastKnownNetwork();
+      }
     }
     if (passiveInterval < Long.MAX_VALUE) {
       enablePassive(passiveInterval);

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
@@ -105,12 +105,15 @@ public class FusionEngine extends LocationEngine implements LocationListener {
 
     if (networkInterval < Long.MAX_VALUE) {
       enableNetwork(networkInterval);
+      checkLastKnownNetwork();
     }
     if (gpsInterval < Long.MAX_VALUE) {
       enableGps(gpsInterval);
+      checkLastKnownGps();
     }
     if (passiveInterval < Long.MAX_VALUE) {
       enablePassive(passiveInterval);
+      checkLastKnownPassive();
     }
   }
 
@@ -141,6 +144,25 @@ public class FusionEngine extends LocationEngine implements LocationListener {
       locationManager.requestLocationUpdates(PASSIVE_PROVIDER, interval, 0, this);
     } catch (IllegalArgumentException e) {
       Log.e(TAG, "Unable to register for passive updates.", e);
+    }
+  }
+
+  private void checkLastKnownGps() {
+    checkLastKnownAndNotify(GPS_PROVIDER);
+  }
+
+  private void checkLastKnownNetwork() {
+    checkLastKnownAndNotify(NETWORK_PROVIDER);
+  }
+
+  private void checkLastKnownPassive() {
+    checkLastKnownAndNotify(PASSIVE_PROVIDER);
+  }
+
+  private void checkLastKnownAndNotify(String provider) {
+    Location location = locationManager.getLastKnownLocation(provider);
+    if (location != null) {
+      onLocationChanged(location);
     }
   }
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusionEngineTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusionEngineTest.java
@@ -287,6 +287,39 @@ public class FusionEngineTest {
     assertThat(callback.location).isEqualTo(networkLocation);
   }
 
+  @Test public void onLocationChanged_gps_shouldReportLastKnownLocation() throws Exception {
+    Location gpsLocation = new Location(GPS_PROVIDER);
+    shadowLocationManager.setLastKnownLocation(GPS_PROVIDER, gpsLocation);
+
+    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
+    fusionEngine.setRequest(request);
+
+    assertThat(callback.location).isEqualTo(gpsLocation);
+  }
+
+  @Test public void onLocationChanged_network_shouldReportLastKnownLocation() throws Exception {
+    Location networkLocation = new Location(NETWORK_PROVIDER);
+    shadowLocationManager.setLastKnownLocation(NETWORK_PROVIDER, networkLocation);
+
+    LocationRequest request = LocationRequest.create().setPriority(
+        PRIORITY_BALANCED_POWER_ACCURACY);
+    fusionEngine.setRequest(request);
+
+    assertThat(callback.location).isEqualTo(networkLocation);
+  }
+
+  @Test public void onLocationChanged_gpsNetwork_shouldReportLastKnownLocation() throws Exception {
+    Location gpsLocation = new Location(GPS_PROVIDER);
+    shadowLocationManager.setLastKnownLocation(GPS_PROVIDER, gpsLocation);
+    Location networkLocation = new Location(NETWORK_PROVIDER);
+    shadowLocationManager.setLastKnownLocation(NETWORK_PROVIDER, networkLocation);
+
+    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
+    fusionEngine.setRequest(request);
+
+    assertThat(callback.location).isEqualTo(networkLocation);
+  }
+
   @Test public void isBetterThan_shouldReturnFalseIfLocationAIsNull() throws Exception {
     Location locationA = null;
     Location locationB = new Location("test");

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusionEngineTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusionEngineTest.java
@@ -320,6 +320,20 @@ public class FusionEngineTest {
     assertThat(callback.location).isEqualTo(networkLocation);
   }
 
+  @Test public void onLocationChanged_gpsNetwork_shouldReportOneLastKnownLocation() throws
+      Exception {
+    Location gpsLocation = new Location(GPS_PROVIDER);
+    shadowLocationManager.setLastKnownLocation(GPS_PROVIDER, gpsLocation);
+    Location networkLocation = new Location(NETWORK_PROVIDER);
+    shadowLocationManager.setLastKnownLocation(NETWORK_PROVIDER, networkLocation);
+
+    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
+    fusionEngine.setRequest(request);
+
+    assertThat(callback.numLocationReports).isEqualTo(1);
+  }
+
+
   @Test public void isBetterThan_shouldReturnFalseIfLocationAIsNull() throws Exception {
     Location locationA = null;
     Location locationB = new Location("test");
@@ -402,9 +416,11 @@ public class FusionEngineTest {
 
   class TestCallback implements LocationEngine.Callback {
     private Location location;
+    private int numLocationReports = 0;
 
     @Override public void reportLocation(Location location) {
       this.location = location;
+      numLocationReports++;
     }
 
     @Override public void reportProviderDisabled(String provider) {


### PR DESCRIPTION
### Overview
This PR updates the `FusionEngine` to check for a last known location for each enabled location provider and return that location if it exists.

### Proposed Changes
Here is example output from these two test classes used

FusedLocationActivity
```
12-06 15:53:11.558 1765-1765/com.mapzen.googleplayservicestest D/Test: onConnected
12-06 15:53:11.568 1765-1765/com.mapzen.googleplayservicestest D/Test: last known network
12-06 15:53:11.568 1765-1765/com.mapzen.googleplayservicestest D/Test: ch acc:2198.0 lat:40.0173948 lng:-105.3028802 provider:network bearing:0.0 nanos:6514803000000 speed:0.0 time:1481064657644
12-06 15:53:11.568 1765-1765/com.mapzen.googleplayservicestest D/Test: lastKnownLocation
12-06 15:53:11.568 1765-1765/com.mapzen.googleplayservicestest D/Test: ch acc:2198.0 lat:40.0173948 lng:-105.3028802 provider:fused bearing:0.0 nanos:6648737000000 speed:0.0 time:1481064791578
12-06 15:53:11.578 1765-1765/com.mapzen.googleplayservicestest D/Test: Location Changed
12-06 15:53:11.578 1765-1765/com.mapzen.googleplayservicestest D/Test: ch acc:2198.0 lat:40.0173948 lng:-105.3028802 provider:fused bearing:0.0 nanos:6648746000000 speed:0.0 time:1481064791587
```

LostFusedLocationActivity
```
12-06 15:50:57.598 30873-30873/com.mapzen.googleplayservicestest D/Test: onConnected
12-06 15:50:57.598 30873-30873/com.mapzen.googleplayservicestest D/Test: last known network
12-06 15:50:57.598 30873-30873/com.mapzen.googleplayservicestest D/Test: ch acc:2198.0 lat:40.0173948 lng:-105.3028802 provider:network bearing:0.0 nanos:6477295000000 speed:0.0 time:1481064620137
12-06 15:50:57.598 30873-30873/com.mapzen.googleplayservicestest D/Test: lastKnownLocation
12-06 15:50:57.598 30873-30873/com.mapzen.googleplayservicestest D/Test: ch acc:2198.0 lat:40.0173948 lng:-105.3028802 provider:network bearing:0.0 nanos:6477295000000 speed:0.0 time:1481064620137
12-06 15:50:57.608 30873-30873/com.mapzen.googleplayservicestest D/Test: Location Changed
12-06 15:50:57.608 30873-30873/com.mapzen.googleplayservicestest D/Test: ch acc:2198.0 lat:40.0173948 lng:-105.3028802 provider:network bearing:0.0 nanos:6477295000000 speed:0.0 time:1481064620137
```

[FusedLocationActivity.txt](https://github.com/mapzen/lost/files/635268/FusedLocationActivity.txt)
[LostFusedLocationActivity.txt](https://github.com/mapzen/lost/files/635269/LostFusedLocationActivity.txt)

Closes #141 