### PR TITLE
Initialize thread as looper if needed

### DIFF
--- a/lost-sample/src/main/AndroidManifest.xml
+++ b/lost-sample/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
     <activity android:name=".SettingsApiActivity"/>
     <activity android:name=".LocationListenerActivity"/>
     <activity android:name=".PendingIntentActivity"/>
+    <activity android:name=".BackgroundPendingIntentActivity"/>
     <activity android:name=".LocationAvailabilityActivity"/>
 
     <service

--- a/lost-sample/src/main/java/com/example/lost/BackgroundPendingIntentActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/BackgroundPendingIntentActivity.java
@@ -1,0 +1,71 @@
+package com.example.lost;
+
+import com.mapzen.android.lost.api.LocationRequest;
+import com.mapzen.android.lost.api.LocationServices;
+
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.View;
+import android.widget.Button;
+
+/**
+ * Requests location updates via {@link PendingIntent} from a background thread
+ */
+public class BackgroundPendingIntentActivity extends LostApiClientActivity {
+
+  @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_pending_intent);
+
+    setupConnectBtn();
+    setupRequestBtn();
+    setupDisconnectBtn();
+  }
+
+  private void setupConnectBtn() {
+    Button connect = (Button) findViewById(R.id.connect);
+    connect.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(View v) {
+        connect();
+      }
+    });
+  }
+
+  private void setupRequestBtn() {
+    Button requestUpdates = (Button) findViewById(R.id.request_updates);
+    requestUpdates.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(View v) {
+        requestLocationUpdates();
+      }
+    });
+  }
+
+  private void setupDisconnectBtn() {
+    Button disconnect = (Button) findViewById(R.id.disconnect);
+    disconnect.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(View v) {
+        disconnect();
+      }
+    });
+  }
+
+  private void requestLocationUpdates() {
+    AsyncTask task = new AsyncTask() {
+      @Override protected Object doInBackground(Object[] objects) {
+        LocationRequest request = LocationRequest.create();
+        request.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+        request.setInterval(100);
+
+        Intent intent = new Intent(PendingIntentService.ACTION);
+        PendingIntent pendingIntent = PendingIntent.getService(BackgroundPendingIntentActivity.this, 1,
+            intent, 0);
+        LocationServices.FusedLocationApi.requestLocationUpdates(client, request, pendingIntent);
+        return null;
+      }
+    };
+    task.execute();
+  }
+}

--- a/lost-sample/src/main/java/com/example/lost/BackgroundPendingIntentActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/BackgroundPendingIntentActivity.java
@@ -60,8 +60,8 @@ public class BackgroundPendingIntentActivity extends LostApiClientActivity {
         request.setInterval(100);
 
         Intent intent = new Intent(PendingIntentService.ACTION);
-        PendingIntent pendingIntent = PendingIntent.getService(BackgroundPendingIntentActivity.this, 1,
-            intent, 0);
+        PendingIntent pendingIntent = PendingIntent.getService(BackgroundPendingIntentActivity.this,
+            1, intent, 0);
         LocationServices.FusedLocationApi.requestLocationUpdates(client, request, pendingIntent);
         return null;
       }

--- a/lost-sample/src/main/java/com/example/lost/SamplesList.java
+++ b/lost-sample/src/main/java/com/example/lost/SamplesList.java
@@ -19,6 +19,8 @@ public class SamplesList {
           R.string.sample_location_listener_description, LocationListenerActivity.class),
       new Sample(R.string.sample_pending_intent_title,
           R.string.sample_pending_intent_description, PendingIntentActivity.class),
+      new Sample(R.string.sample_bg_pending_intent_title,
+          R.string.sample_bg_pending_intent_description, BackgroundPendingIntentActivity.class),
       new Sample(R.string.sample_location_availability_title,
           R.string.sample_location_availability_description, LocationAvailabilityActivity.class)
   };

--- a/lost-sample/src/main/res/values/strings.xml
+++ b/lost-sample/src/main/res/values/strings.xml
@@ -70,6 +70,8 @@
   <string name="pending_intent">Pending Intent</string>
   <string name="sample_pending_intent_title">PendingIntent</string>
   <string name="sample_pending_intent_description">Demonstrates how to use a PendingIntent to receive location updates</string>
+  <string name="sample_bg_pending_intent_title">Background PendingIntent</string>
+  <string name="sample_bg_pending_intent_description">Demonstrates how to use a PendingIntent to receive location updates when requesting updates from a background thread.</string>
   <string name="requested">Requested</string>
   <string name="sample_location_availability_title">Location Availability</string>
   <string name="sample_location_availability_description">Demonstrates how to determine if location requested is available</string>

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
@@ -7,6 +7,7 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
+import android.os.Looper;
 import android.util.Log;
 
 import java.util.List;
@@ -74,6 +75,11 @@ public class FusionEngine extends LocationEngine implements LocationListener {
   }
 
   @Override protected void enable() {
+    boolean prepLooper = Looper.myLooper() == null;
+    if (prepLooper) {
+      Looper.prepare();
+    }
+
     long networkInterval = Long.MAX_VALUE;
     long gpsInterval = Long.MAX_VALUE;
     long passiveInterval = Long.MAX_VALUE;
@@ -111,6 +117,10 @@ public class FusionEngine extends LocationEngine implements LocationListener {
     }
     if (passiveInterval < Long.MAX_VALUE) {
       enablePassive(passiveInterval);
+    }
+
+    if (prepLooper) {
+      Looper.loop();
     }
   }
 


### PR DESCRIPTION
### Overview
Allow requesting location updates from a background thread without requiring the thread to initialize itself as a looper and setup the message queue to run in it.

### Proposed Changes
This PR prepares the current thread to request location updates (like a certain other location library does).

Closes #131 
