### PR TITLE
Display alert to optionally fire location settings activity

### DIFF
--- a/lost/build.gradle
+++ b/lost/build.gradle
@@ -65,12 +65,14 @@ task checkstyle(type: Checkstyle) {
 
 dependencies {
   compile 'com.android.support:support-annotations:24.2.1'
+  compile 'com.android.support:appcompat-v7:24.2.1'
 
   testCompile 'com.google.guava:guava:18.0'
   testCompile 'junit:junit:4.12'
   testCompile 'org.robolectric:robolectric:3.1.2'
   testCompile 'com.squareup:fest-android:1.0.7'
   testCompile 'org.mockito:mockito-core:1.9.5'
+
 }
 
 apply from: file('../gradle-mvn-push.gradle')

--- a/lost/src/main/java/com/mapzen/android/lost/api/Status.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/Status.java
@@ -1,5 +1,7 @@
 package com.mapzen.android.lost.api;
 
+import com.mapzen.android.lost.internal.DialogDisplayer;
+
 import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.IntentSender;
@@ -19,13 +21,14 @@ public class Status implements Result {
 
   private final int statusCode;
   private final String statusMessage;
-  private final PendingIntent mPendingIntent;
+  private final PendingIntent pendingIntent;
+  private final DialogDisplayer dialogDisplayer;
 
-  public Status(int statusCode) {
-    this(statusCode, null);
+  public Status(int statusCode, DialogDisplayer dialogDisplayer) {
+    this(statusCode, dialogDisplayer, null);
   }
 
-  public Status(int statusCode, PendingIntent pendingIntent) {
+  public Status(int statusCode, DialogDisplayer dialogDisplayer, PendingIntent pendingIntent) {
     String statusMessage;
     switch (statusCode) {
       case SUCCESS:
@@ -55,7 +58,8 @@ public class Status implements Result {
     }
     this.statusCode = statusCode;
     this.statusMessage = statusMessage;
-    this.mPendingIntent = pendingIntent;
+    this.pendingIntent = pendingIntent;
+    this.dialogDisplayer = dialogDisplayer;
   }
 
   /**
@@ -67,11 +71,10 @@ public class Status implements Result {
    * @param requestCode associated with activity.
    * @throws IntentSender.SendIntentException
    */
-  public void startResolutionForResult(Activity activity, int requestCode)
+  public void startResolutionForResult(final Activity activity, final int requestCode)
       throws IntentSender.SendIntentException {
     if (this.hasResolution()) {
-      activity.startIntentSenderForResult(this.mPendingIntent.getIntentSender(), requestCode, null,
-          0, 0, 0);
+      dialogDisplayer.displayDialog(activity, requestCode, pendingIntent);
     }
   }
 
@@ -88,7 +91,7 @@ public class Status implements Result {
    * @return whether or not there is a resolution.
    */
   public boolean hasResolution() {
-    return this.mPendingIntent != null;
+    return this.pendingIntent != null;
   }
 
   /**
@@ -128,7 +131,7 @@ public class Status implements Result {
    * @return the {@link PendingIntent}.
    */
   public PendingIntent getResolution() {
-    return this.mPendingIntent;
+    return this.pendingIntent;
   }
 
   @Override public Status getStatus() {

--- a/lost/src/main/java/com/mapzen/android/lost/api/Status.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/Status.java
@@ -66,7 +66,11 @@ public class Status implements Result {
    * If the status code is {@link Status#RESOLUTION_REQUIRED}, then this method can be called to
    * start the resolution. For example, it will launch the Settings {@link Activity} so that the
    * user can update location settings when used with {@link SettingsApi#checkLocationSettings(
-   * LostApiClient, LocationSettingsRequest)}
+   * LostApiClient, LocationSettingsRequest)}. This activity will finish with
+   * {@link Activity#onActivityResult(int, int, android.content.Intent)} but the resultCode will
+   * never be {@code Activity#RESULT_OK}. You should instead rely on the requestCode to determine
+   * application flow and assume that the result is {@code Activity#RESULT_OK}.
+   *
    * @param activity to launch for resolution.
    * @param requestCode associated with activity.
    * @throws IntentSender.SendIntentException

--- a/lost/src/main/java/com/mapzen/android/lost/internal/DialogDisplayer.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/DialogDisplayer.java
@@ -1,0 +1,13 @@
+package com.mapzen.android.lost.internal;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+
+/**
+ * Created by sarahlensing on 12/12/16.
+ */
+
+public interface DialogDisplayer {
+  void displayDialog(final Activity activity, final int requestCode, final PendingIntent
+      pendingIntent);
+}

--- a/lost/src/main/java/com/mapzen/android/lost/internal/DialogDisplayer.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/DialogDisplayer.java
@@ -4,10 +4,17 @@ import android.app.Activity;
 import android.app.PendingIntent;
 
 /**
- * Created by sarahlensing on 12/12/16.
+ * Interface for displaying a dialog in an {@link android.app.Activity} for a given code and
+ * {@link android.app.PendingIntent}.
  */
-
 public interface DialogDisplayer {
+  /**
+   * Implementing class should display a dialog in the given {@link android.app.Activity} passing
+   * the request and {@link android.app.PendingIntent}.
+   * @param activity
+   * @param requestCode
+   * @param pendingIntent
+   */
   void displayDialog(final Activity activity, final int requestCode, final PendingIntent
       pendingIntent);
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LocationSettingsResultRequest.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LocationSettingsResultRequest.java
@@ -37,6 +37,7 @@ class LocationSettingsResultRequest extends PendingResult<LocationSettingsResult
   private final LocationSettingsRequest settingsRequest;
   private ResultCallback<? super LocationSettingsResult> resultCallback;
   private Future<LocationSettingsResult> future;
+  private SettingsDialogDisplayer dialogDisplayer = new SettingsDialogDisplayer();
 
   LocationSettingsResultRequest(Context context, PendingIntentGenerator generator,
       LocationSettingsRequest request) {
@@ -124,11 +125,11 @@ class LocationSettingsResultRequest extends PendingResult<LocationSettingsResult
     final Status status;
     if (hasResolution) {
       PendingIntent pendingIntent = pendingIntentGenerator.generatePendingIntent();
-      status = new Status(RESOLUTION_REQUIRED, pendingIntent);
+      status = new Status(RESOLUTION_REQUIRED, dialogDisplayer, pendingIntent);
     } else if (resolutionUnavailable) {
-      status = new Status(SETTINGS_CHANGE_UNAVAILABLE);
+      status = new Status(SETTINGS_CHANGE_UNAVAILABLE, dialogDisplayer);
     } else {
-      status = new Status(SUCCESS);
+      status = new Status(SUCCESS, dialogDisplayer);
     }
     final LocationSettingsStates states =
         new LocationSettingsStates(gpsUsable, networkUsable, bleUsable, gpsPresent, networkPresent,
@@ -159,7 +160,7 @@ class LocationSettingsResultRequest extends PendingResult<LocationSettingsResult
   }
 
   private LocationSettingsResult createResultForStatus(int statusType) {
-    Status status = new Status(statusType);
+    Status status = new Status(statusType, dialogDisplayer);
     return new LocationSettingsResult(status, null);
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/SettingsDialogDisplayer.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/SettingsDialogDisplayer.java
@@ -1,0 +1,31 @@
+package com.mapzen.android.lost.internal;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.DialogInterface;
+import android.content.IntentSender;
+
+/**
+ * Handles displaying a dialog to the user so that they can optionally update their device location
+ * settings.
+ */
+public class SettingsDialogDisplayer implements DialogDisplayer {
+
+  private static final String SETTINGS_DIALOG_TAG = "settings-dialog";
+
+  @Override public void displayDialog(final Activity activity, final int requestCode,
+      final PendingIntent pendingIntent) {
+    SettingsDialogFragment fragment = new SettingsDialogFragment();
+    fragment.setOnClickListener(new DialogInterface.OnClickListener() {
+      @Override public void onClick(DialogInterface dialogInterface, int i) {
+        try {
+          activity.startIntentSenderForResult(pendingIntent.getIntentSender(),
+              requestCode, null, 0, 0, 0);
+        } catch (IntentSender.SendIntentException e) {
+          e.printStackTrace();
+        }
+      }
+    });
+    fragment.show(activity.getFragmentManager(), SETTINGS_DIALOG_TAG);
+  }
+}

--- a/lost/src/main/java/com/mapzen/android/lost/internal/SettingsDialogFragment.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/SettingsDialogFragment.java
@@ -1,0 +1,38 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.lost.R;
+
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
+
+/**
+ * Handles displaying a dialog to prompt the user to resolve location settings
+ */
+public class SettingsDialogFragment extends DialogFragment implements
+    DialogInterface.OnClickListener {
+
+  private DialogInterface.OnClickListener externalListener;
+
+  public void setOnClickListener(DialogInterface.OnClickListener listener) {
+    externalListener = listener;
+  }
+
+  @Override public Dialog onCreateDialog(Bundle savedInstanceState) {
+    return new AlertDialog.Builder(this.getActivity())
+        .setTitle(null)
+        .setMessage(R.string.settings_alert_title)
+        .setNegativeButton(R.string.cancel, null)
+        .setPositiveButton(R.string.ok, this)
+        .create();
+  }
+
+  @Override public void onClick(DialogInterface dialogInterface, int i) {
+    if (externalListener != null) {
+      externalListener.onClick(dialogInterface, i);
+    }
+  }
+
+}

--- a/lost/src/main/java/com/mapzen/android/lost/internal/SimplePendingResult.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/SimplePendingResult.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 public class SimplePendingResult extends PendingResult<Status> {
 
   private boolean hasResult = false;
+  private SettingsDialogDisplayer dialogDisplayer = new SettingsDialogDisplayer();
 
   public SimplePendingResult(boolean hasResult) {
     this.hasResult = hasResult;
@@ -47,7 +48,7 @@ public class SimplePendingResult extends PendingResult<Status> {
   }
 
   private Status generateStatus() {
-    return new Status(Status.SUCCESS);
+    return new Status(Status.SUCCESS, dialogDisplayer);
   }
 
   private Result generateResult() {

--- a/lost/src/main/res/values/strings.xml
+++ b/lost/src/main/res/values/strings.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="settings_alert_title">For best results let your device turn on location using
-  Mapzen\'s location service.\n\nClicking \"OK\" will bring you to the device\'s location settings screen.</string>
+  Mapzen\'s location service.\n\nClicking \"OK\" will bring you to the device\'s location settings
+    screen. Remember to press the back key after updating your location settings.</string>
   <string name="cancel">Cancel</string>
   <string name="ok">Ok</string>
 </resources>

--- a/lost/src/main/res/values/strings.xml
+++ b/lost/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="settings_alert_title">For best results let your device turn on location using
+  Mapzen\'s location service.\n\nClicking \"OK\" will bring you to the device\'s location settings screen.</string>
+  <string name="cancel">Cancel</string>
+  <string name="ok">Ok</string>
+</resources>

--- a/lost/src/test/java/com/mapzen/android/lost/api/LocationSettingsResultTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/api/LocationSettingsResultTest.java
@@ -1,5 +1,7 @@
 package com.mapzen.android.lost.api;
 
+import com.mapzen.android.lost.internal.TestSettingsDialogDisplayer;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -12,7 +14,7 @@ public class LocationSettingsResultTest {
   LocationSettingsResult result;
 
   @Before public void setup() {
-    status = new Status(Status.SUCCESS);
+    status = new Status(Status.SUCCESS, new TestSettingsDialogDisplayer());
     states = new LocationSettingsStates(true, true, true, true, true, true);
     result = new LocationSettingsResult(status, states);
   }

--- a/lost/src/test/java/com/mapzen/android/lost/api/StatusTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/api/StatusTest.java
@@ -1,12 +1,16 @@
 package com.mapzen.android.lost.api;
 
+import com.mapzen.android.lost.internal.TestSettingsDialogDisplayer;
+
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
+import android.app.Activity;
 import android.app.PendingIntent;
+import android.content.IntentSender;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class StatusTest {
 
@@ -14,8 +18,8 @@ public class StatusTest {
   Status status;
 
   @Before public void setup() {
-    pendingIntent = Mockito.mock(PendingIntent.class);
-    status = new Status(Status.SUCCESS, pendingIntent);
+    pendingIntent = mock(PendingIntent.class);
+    status = new Status(Status.SUCCESS, new TestSettingsDialogDisplayer(), pendingIntent);
   }
 
   @Test public void shouldHaveSuccessStatus() {
@@ -28,5 +32,13 @@ public class StatusTest {
 
   @Test public void shouldHaveStatusMessage() {
     assertThat(status.getStatusMessage()).isEqualTo("SUCCESS");
+  }
+
+  @Test public void resolveSettings_shouldInvokeDialogDisplayer()
+      throws IntentSender.SendIntentException {
+    TestSettingsDialogDisplayer dialogDisplayer = new TestSettingsDialogDisplayer();
+    Status s = new Status(Status.RESOLUTION_REQUIRED, dialogDisplayer, pendingIntent);
+    s.startResolutionForResult(mock(Activity.class), 1);
+    assertThat(dialogDisplayer.isDisplayed()).isTrue();
   }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestSettingsDialogDisplayer.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestSettingsDialogDisplayer.java
@@ -1,0 +1,18 @@
+package com.mapzen.android.lost.internal;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+
+public class TestSettingsDialogDisplayer implements DialogDisplayer {
+
+  boolean displayed = false;
+
+  @Override
+  public void displayDialog(Activity activity, int requestCode, PendingIntent pendingIntent) {
+    displayed = true;
+  }
+
+  public boolean isDisplayed() {
+    return displayed;
+  }
+}


### PR DESCRIPTION
### Overview
This adds an intermediate step between initiation of a Status' resolution and firing of the device's location activity to give the user a chance to reject changing location settings.

### Proposed Changes
Creates a new class, `SettingsDialogDisplayer` to handle showing an alert to prompt the user to continue to the device's location settings screen.

![screenshot_20161212-131802](https://cloud.githubusercontent.com/assets/494323/21111716/dc43413a-c070-11e6-8961-f244b0e04486.png)

Closes #140 
