### PR TITLE
Extracts `LocationClientWrapper` class

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostClientWrapper.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostClientWrapper.java
@@ -1,0 +1,50 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LocationCallback;
+import com.mapzen.android.lost.api.LocationListener;
+import com.mapzen.android.lost.api.LostApiClient;
+
+import android.app.PendingIntent;
+import android.os.Looper;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Wraps an instance of {@link LostApiClient} along with its registered {@link LocationListener},
+ * {@link PendingIntent}, or {@link LocationCallback} objects to be notified with location updates.
+ */
+class LostClientWrapper {
+  private final LostApiClient client;
+
+  private Set<LocationListener> locationListeners = new HashSet<>();
+  private Set<PendingIntent> pendingIntents = new HashSet<>();
+  private Set<LocationCallback> locationCallbacks = new HashSet<>();
+  private Map<LocationCallback, Looper> looperMap = new HashMap<>();
+
+  LostClientWrapper(LostApiClient client) {
+    this.client = client;
+  }
+
+  public LostApiClient client() {
+    return client;
+  }
+
+  Set<LocationListener> locationListeners() {
+    return locationListeners;
+  }
+
+  Set<PendingIntent> pendingIntents() {
+    return pendingIntents;
+  }
+
+  Set<LocationCallback> locationCallbacks() {
+    return locationCallbacks;
+  }
+
+  Map<LocationCallback, Looper> looperMap() {
+    return looperMap;
+  }
+}

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
@@ -1,17 +1,5 @@
 package com.mapzen.android.lost.internal;
 
-import android.app.IntentService;
-import android.app.PendingIntent;
-import android.content.ComponentName;
-import android.content.Context;
-import android.content.Intent;
-import android.location.Location;
-import android.location.LocationManager;
-import android.os.Environment;
-import android.os.Looper;
-
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import com.mapzen.android.lost.api.LocationAvailability;
 import com.mapzen.android.lost.api.LocationCallback;
 import com.mapzen.android.lost.api.LocationListener;
@@ -23,16 +11,29 @@ import com.mapzen.android.lost.api.Status;
 import com.mapzen.android.lost.shadows.LostShadowLocationManager;
 import com.mapzen.lost.BuildConfig;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.internal.ShadowExtractor;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowEnvironment;
 import org.robolectric.shadows.ShadowLooper;
+
+import android.app.IntentService;
+import android.app.PendingIntent;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.location.Location;
+import android.location.LocationManager;
+import android.os.Environment;
+import android.os.Looper;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -51,7 +52,7 @@ import static org.mockito.Mockito.when;
 import static org.robolectric.RuntimeEnvironment.application;
 import static org.robolectric.Shadows.shadowOf;
 
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 @SuppressWarnings("MissingPermission")
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE, shadows = {
         LostShadowLocationManager.class})
@@ -676,7 +677,7 @@ public class FusedLocationProviderServiceImplTest {
     otherClient.connect();
 
     assertThat(api.getLocationListeners().get(client).size()).isEqualTo(1);
-    assertThat(api.getLocationListeners().get(otherClient)).isNull();
+    assertThat(api.getLocationListeners().get(otherClient)).isEmpty();
   }
 
   @Test public void requestLocationUpdates_shouldModifyOnlyClientPendingIntents() {
@@ -687,7 +688,7 @@ public class FusedLocationProviderServiceImplTest {
     otherClient.connect();
 
     assertThat(api.getPendingIntents().get(client).size()).isEqualTo(1);
-    assertThat(api.getPendingIntents().get(otherClient)).isNull();
+    assertThat(api.getPendingIntents().get(otherClient)).isEmpty();
   }
 
   @Test public void requestLocationUpdates_shouldModifyOnlyClientLocationListeners() {
@@ -698,7 +699,7 @@ public class FusedLocationProviderServiceImplTest {
     otherClient.connect();
 
     assertThat(api.getLocationCallbacks().get(client).size()).isEqualTo(1);
-    assertThat(api.getLocationCallbacks().get(otherClient)).isNull();
+    assertThat(api.getLocationCallbacks().get(otherClient)).isEmpty();
   }
 
   @Test public void removeLocationUpdates_shouldModifyOnlyClientListeners() {
@@ -714,7 +715,7 @@ public class FusedLocationProviderServiceImplTest {
 
     api.removeLocationUpdates(client, listener);
 
-    assertThat(api.getLocationListeners().get(client)).isNull();
+    assertThat(api.getLocationListeners().get(client)).isEmpty();
     assertThat(api.getLocationListeners().get(otherClient).size()).isEqualTo(1);
   }
 
@@ -731,7 +732,7 @@ public class FusedLocationProviderServiceImplTest {
 
     api.removeLocationUpdates(client, pendingIntent);
 
-    assertThat(api.getPendingIntents().get(client)).isNull();
+    assertThat(api.getPendingIntents().get(client)).isEmpty();
     assertThat(api.getPendingIntents().get(otherClient).size()).isEqualTo(1);
   }
 
@@ -748,7 +749,7 @@ public class FusedLocationProviderServiceImplTest {
 
     api.removeLocationUpdates(client, callback);
 
-    assertThat(api.getLocationCallbacks().get(client)).isNull();
+    assertThat(api.getLocationCallbacks().get(client)).isEmpty();
     assertThat(api.getLocationCallbacks().get(otherClient).size()).isEqualTo(1);
   }
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostClientManagerTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostClientManagerTest.java
@@ -9,7 +9,7 @@ import com.mapzen.lost.BuildConfig;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 
@@ -26,7 +26,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.robolectric.RuntimeEnvironment.application;
 
-@RunWith(RobolectricGradleTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
 public class LostClientManagerTest {
 
@@ -58,7 +58,24 @@ public class LostClientManagerTest {
     manager.removeClient(anotherClient);
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void addListener_shouldThrowExceptionIfClientWasNotAdded() throws Exception {
+    manager.addListener(client, LocationRequest.create(), new TestLocationListener());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void addPendingIntent_shouldThrowExceptionIfClientWasNotAdded() throws Exception {
+    manager.addPendingIntent(client, LocationRequest.create(), mock(PendingIntent.class));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void addLocationCallback_shouldThrowExceptionIfClientWasNotAdded() throws Exception {
+    manager.addLocationCallback(client, LocationRequest.create(), new TestLocationCallback(),
+        mock(Looper.class));
+  }
+
   @Test public void addListener_shouldAddListenerForClient() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationListener listener = new TestLocationListener();
     manager.addListener(client, request, listener);
@@ -66,6 +83,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void addPendingIntent_shouldAddPendingIntentForClient() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     PendingIntent pendingIntent = mock(PendingIntent.class);
     manager.addPendingIntent(client, request, pendingIntent);
@@ -73,6 +91,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void addLocationCallback_shouldAddLocationCallbackForClient() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationCallback callback = new TestLocationCallback();
     Looper looper = mock(Looper.class);
@@ -81,31 +100,35 @@ public class LostClientManagerTest {
   }
 
   @Test public void removeListener_shouldRemoveListenerForClient() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationListener listener = new TestLocationListener();
     manager.addListener(client, request, listener);
     manager.removeListener(client, listener);
-    assertThat(manager.getLocationListeners().get(client)).isNull();
+    assertThat(manager.getLocationListeners().get(client)).isEmpty();
   }
 
   @Test public void removePendingIntent_shouldRemovePendingIntentForClient() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     PendingIntent pendingIntent = mock(PendingIntent.class);
     manager.addPendingIntent(client, request, pendingIntent);
     manager.removePendingIntent(client, pendingIntent);
-    assertThat(manager.getPendingIntents().get(client)).isNull();
+    assertThat(manager.getPendingIntents().get(client)).isEmpty();
   }
 
   @Test public void removeLocationCallback_shouldRemoveLocationCallbackForClient() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationCallback callback = new TestLocationCallback();
     Looper looper = mock(Looper.class);
     manager.addLocationCallback(client, request, callback, looper);
     manager.removeLocationCallback(client, callback);
-    assertThat(manager.getLocationCallbacks().get(client)).isNull();
+    assertThat(manager.getLocationCallbacks().get(client)).isEmpty();
   }
 
   @Test public void reportLocationChanged_shouldNotifyListener() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationListener listener = new TestLocationListener();
     manager.addListener(client, request, listener);
@@ -115,6 +138,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void sendPendingIntent_shouldFireIntent() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     Intent intent = new Intent(application, FusedLocationProviderServiceImplTest.TestService.class);
     PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
@@ -134,6 +158,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void reportLocationResult_shouldNotifyCallback() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationCallback callback = new TestLocationCallback();
     Looper looper = Looper.myLooper();
@@ -147,6 +172,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void reportProviderEnabled_shouldNotifyListeners() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationListener listener = new TestLocationListener();
     manager.addListener(client, request, listener);
@@ -155,6 +181,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void reportProviderDisabled_shouldNotifyListeners() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationListener listener = new TestLocationListener();
     manager.addListener(client, request, listener);
@@ -163,6 +190,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void notifyLocationAvailability_shouldNotifyCallback() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationCallback callback = new TestLocationCallback();
     Looper looper = Looper.myLooper();
@@ -173,10 +201,12 @@ public class LostClientManagerTest {
   }
 
   @Test public void hasNoListeners_shouldReturnTrue() {
+    manager.addClient(client);
     assertThat(manager.hasNoListeners()).isTrue();
   }
 
   @Test public void hasNoListeners_shouldReturnFalseWhenListenerAdded() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationListener listener = new TestLocationListener();
     manager.addListener(client, request, listener);
@@ -184,6 +214,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void hasNoListeners_shouldReturnFalseWhenPendingIntentAdded() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     PendingIntent pendingIntent = mock(PendingIntent.class);
     manager.addPendingIntent(client, request, pendingIntent);
@@ -191,6 +222,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void hasNoListeners_shouldReturnFalseWhenCallbackAdded() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationCallback callback = new TestLocationCallback();
     Looper looper = mock(Looper.class);
@@ -199,6 +231,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void removeClient_shouldRemoveListenersForClient() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationListener listener = new TestLocationListener();
     manager.addListener(client, request, listener);
@@ -207,6 +240,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void removeClient_shouldRemovePendingIntentsForClient() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     PendingIntent pendingIntent = mock(PendingIntent.class);
     manager.addPendingIntent(client, request, pendingIntent);
@@ -215,6 +249,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void removeClient_shouldRemoveCallbacksForClient() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationCallback callback = new TestLocationCallback();
     Looper looper = mock(Looper.class);
@@ -224,6 +259,7 @@ public class LostClientManagerTest {
   }
 
   @Test public void shutdown_shouldClearAllMaps() {
+    manager.addClient(client);
     LocationRequest request = LocationRequest.create();
     TestLocationListener listener = new TestLocationListener();
     manager.addListener(client, request, listener);
@@ -240,5 +276,4 @@ public class LostClientManagerTest {
     assertThat(manager.getPendingIntents()).isEmpty();
     assertThat(manager.getLocationCallbacks()).isEmpty();
   }
-
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostClientWrapperTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostClientWrapperTest.java
@@ -1,0 +1,27 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LostApiClient;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class LostClientWrapperTest {
+  private LostClientWrapper wrapper;
+  private LostApiClient client;
+
+  @Before public void setUp() throws Exception {
+    client = new LostApiClient.Builder(RuntimeEnvironment.application).build();
+    wrapper = new LostClientWrapper(client);
+  }
+
+  @Test public void shouldNotBeNull() throws Exception {
+    assertThat(wrapper).isNotNull();
+  }
+
+  @Test public void shouldExposeClient() throws Exception {
+    assertThat(wrapper.client()).isEqualTo(client);
+  }
+}


### PR DESCRIPTION
### Overview

Adds `LocationClientWrapper` class to encapsulate a single `LostApiClient` and all its associated listeners, pending intents, callbacks, and loopers.

### Proposed Changes

This change simplifies the logic in `LostClientManager` for adding and removing listeners and sending location updates.

As a second stage to this refactor we may want to consider migrating some of the logic from `LostClientManager.iterateAndNotify()` into the `ClientWrapper` class.