### PR TITLE
Add constructor for status with only status code param

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/api/Status.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/Status.java
@@ -26,6 +26,10 @@ public class Status implements Result, Parcelable {
   private final PendingIntent pendingIntent;
   private final DialogDisplayer dialogDisplayer;
 
+  public Status(int statusCode) {
+    this(statusCode, null, null);
+  }
+
   public Status(int statusCode, DialogDisplayer dialogDisplayer) {
     this(statusCode, dialogDisplayer, null);
   }
@@ -114,7 +118,7 @@ public class Status implements Result, Parcelable {
    * @return whether or not there is a resolution.
    */
   public boolean hasResolution() {
-    return this.pendingIntent != null;
+    return this.pendingIntent != null && dialogDisplayer != null;
   }
 
   /**

--- a/lost/src/test/java/com/mapzen/android/lost/api/StatusTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/api/StatusTest.java
@@ -41,4 +41,9 @@ public class StatusTest {
     s.startResolutionForResult(mock(Activity.class), 1);
     assertThat(dialogDisplayer.isDisplayed()).isTrue();
   }
+
+  @Test public void shouldNotHaveResolution() {
+    Status s = new Status(Status.RESOLUTION_REQUIRED);
+    assertThat(s.hasResolution()).isFalse();
+  }
 }


### PR DESCRIPTION
### Overview
Adds a constructor to allow creating `Status` objects given only a `statusCode`

### Proposed Changes
This is useful for cases where the status code is `SUCCESS`