### PR TITLE
Upgrades Android Gradle plugin to version 2.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.1'
+    classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,4 +18,4 @@ allprojects {
   }
 }
 
-defaultTasks = ['clean', 'test', 'install', 'checkstyle']
+defaultTasks = ['clean', 'testDebugUnitTest', 'install', 'checkstyle']

--- a/lost-sample/build.gradle
+++ b/lost-sample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.1'
+    classpath 'com.android.tools.build:gradle:2.2.3'
   }
 }
 

--- a/lost/build.gradle
+++ b/lost/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.1'
+    classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
   }
 }


### PR DESCRIPTION
### Overview

Upgrades Android Gradle plugin to version 2.2.3

### Proposed Changes

Replace version 2.2.1 with 2.2.3 in `build.gradle` files.

Also updates Gradle default tasks to run debug tests only. Fixes OOM error on Circle CI.