### PR TITLE
Configure release plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.1'
+    classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,4 +18,4 @@ allprojects {
   }
 }
 
-defaultTasks = ['clean', 'test', 'install', 'checkstyle']
+defaultTasks = ['clean', 'testDebugUnitTest', 'install', 'checkstyle']

--- a/circle.yml
+++ b/circle.yml
@@ -17,3 +17,8 @@ deployment:
     branch: master
     commands:
       - ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
+  release:
+     tag: /lost-[0-9]+(\.[0-9]+)*/
+     owner: mapzen
+     commands:
+      - scripts/deploy-staging.sh

--- a/lost-sample/build.gradle
+++ b/lost-sample/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.1'
+    classpath 'com.android.tools.build:gradle:2.2.3'
   }
 }
 

--- a/lost/build.gradle
+++ b/lost/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.1'
+    classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
   }
 }

--- a/lost/build.gradle
+++ b/lost/build.gradle
@@ -5,12 +5,14 @@ buildscript {
   dependencies {
     classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+    classpath 'net.researchgate:gradle-release:2.4.0'
   }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'checkstyle'
+apply plugin: 'net.researchgate.release'
 
 group = GROUP
 version = VERSION_NAME
@@ -20,6 +22,12 @@ allprojects {
     mavenLocal()
     jcenter()
   }
+}
+
+release {
+  tagTemplate = 'lost-${version}'
+  versionPropertyFile = '../gradle.properties'
+  versionProperties = ['VERSION_NAME']
 }
 
 android {

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Builds, signs, and uploads release AARs to https://oss.sonatype.org/#stagingRepositories.
+#
+
+echo -e "machine github.com\n  login $GITHUB_USERNAME\n  password $GITHUB_PASSWORD" >> ~/.netrc
+git clone https://github.com/mapzen/android-config.git
+./gradlew uploadArchives -PsonatypeUsername="$SONATYPE_NEXUS_SNAPSHOTS_USERNAME" \
+    -PsonatypePassword="$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD" \
+    -Psigning.keyId="$SIGNING_KEY_ID" \
+    -Psigning.password="$SIGNING_PASSWORD" \
+    -Psigning.secretKeyRingFile="$SIGNING_SECRET_KEY_RING_FILE"


### PR DESCRIPTION
### Overview

Configures gradle release plugin and `circle.yml` to deploy AAR to Maven Central directly from Circle CI when a new release tag is pushed to Github.

### Proposed Changes

* Adds gradle-release plugin to library `build.gradle`.
* Adds `release` deployment section to `circle.yml`.
* Adds `deploy-staging.sh` script to build, sign, and upload release artifact.