### PR TITLE
Build performance improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,4 +18,16 @@ allprojects {
   }
 }
 
+project.ext.preDexLibs = !project.hasProperty('disablePreDex')
+
+subprojects {
+  project.plugins.whenPluginAdded { plugin ->
+    if ("com.android.build.gradle.AppPlugin".equals(plugin.class.name)) {
+      project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
+    } else if ("com.android.build.gradle.LibraryPlugin".equals(plugin.class.name)) {
+      project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
+    }
+  }
+}
+
 defaultTasks = ['clean', 'testDebugUnitTest', 'install', 'checkstyle']

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   java:
     version: oraclejdk8
+  environment:
+    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
 
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,9 @@ machine:
 
 dependencies:
   pre:
-    - if [ ! -e /usr/local/android-sdk-linux/build-tools/24.0.2 ]; then echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.2" fi;
-    - if [ ! -e /usr/local/android-sdk-linux/platforms/android-24 ]; then echo y | android update sdk --all --no-ui --force --filter "android-24" fi;
-    - if [ ! -e /usr/local/android-sdk-linux/extras/android/m2repository ]; then echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository" fi;
+    - if [ ! -e /usr/local/android-sdk-linux/build-tools/24.0.2 ]; then echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.2"; fi;
+    - if [ ! -e /usr/local/android-sdk-linux/platforms/android-24 ]; then echo y | android update sdk --all --no-ui --force --filter "android-24"; fi;
+    - if [ ! -e /usr/local/android-sdk-linux/extras/android/m2repository ]; then echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository"; fi;
   cache_directories:
     - /usr/local/android-sdk-linux/build-tools/24.0.2
     - /usr/local/android-sdk-linux/platforms/android-24

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   pre:
     - if [ ! -e /usr/local/android-sdk-linux/build-tools/24.0.2 ]; then echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.2"; fi;
     - if [ ! -e /usr/local/android-sdk-linux/platforms/android-24 ]; then echo y | android update sdk --all --no-ui --force --filter "android-24"; fi;
-    - if ! $(grep -q "Revision=41.0.0" $ANDROID_HOME/extras/android/m2repository/source.properties); then echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository"; fi;
+    - if ! $(grep -q "Revision=41.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository"; fi;
   cache_directories:
     - /usr/local/android-sdk-linux/build-tools/24.0.2
     - /usr/local/android-sdk-linux/platforms/android-24

--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,9 @@ machine:
 
 dependencies:
   pre:
-    - if [ ! -e /usr/local/android-sdk-linux/build-tools/24.0.2 ]; then echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.2"; fi;
-    - if [ ! -e /usr/local/android-sdk-linux/platforms/android-24 ]; then echo y | android update sdk --all --no-ui --force --filter "android-24"; fi;
-    - if ! $(grep -q "Revision=41.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository"; fi;
+    - if [ ! -e /usr/local/android-sdk-linux/build-tools/24.0.2 ]; then echo y | android update sdk --all --no-ui --filter "build-tools-24.0.2"; fi;
+    - if [ ! -e /usr/local/android-sdk-linux/platforms/android-24 ]; then echo y | android update sdk --all --no-ui --filter "android-24"; fi;
+    - if ! $(grep -q "Revision=41.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --all --no-ui --filter "extra-android-m2repository"; fi;
   cache_directories:
     - /usr/local/android-sdk-linux/build-tools/24.0.2
     - /usr/local/android-sdk-linux/platforms/android-24

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   pre:
     - if [ ! -e /usr/local/android-sdk-linux/build-tools/24.0.2 ]; then echo y | android update sdk --all --no-ui --filter "build-tools-24.0.2"; fi;
     - if [ ! -e /usr/local/android-sdk-linux/platforms/android-24 ]; then echo y | android update sdk --all --no-ui --filter "android-24"; fi;
-    - if ! $(grep -q "Revision=41.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --all --no-ui --filter "extra-android-m2repository"; fi;
+    - if ! $(grep -q "Revision=43.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --all --no-ui --filter "extra-android-m2repository"; fi;
   cache_directories:
     - /usr/local/android-sdk-linux/build-tools/24.0.2
     - /usr/local/android-sdk-linux/platforms/android-24

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
 
 test:
   override:
-    - ./gradlew
+    - ./gradlew -PdisablePreDex
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,6 @@
 machine:
   java:
     version: oraclejdk8
-  environment:
-    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
 
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,13 @@ machine:
 
 dependencies:
   pre:
-    - echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.2"
-    - echo y | android update sdk --all --no-ui --force --filter "android-24"
-    - echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository"
+    - if [ ! -e /usr/local/android-sdk-linux/build-tools/24.0.2 ]; then echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.2" fi;
+    - if [ ! -e /usr/local/android-sdk-linux/platforms/android-24 ]; then echo y | android update sdk --all --no-ui --force --filter "android-24" fi;
+    - if [ ! -e /usr/local/android-sdk-linux/extras/android/m2repository ]; then echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository" fi;
+  cache_directories:
+    - /usr/local/android-sdk-linux/build-tools/24.0.2
+    - /usr/local/android-sdk-linux/platforms/android-24
+    - /usr/local/android-sdk-linux/extras/android/m2repository
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   pre:
     - if [ ! -e /usr/local/android-sdk-linux/build-tools/24.0.2 ]; then echo y | android update sdk --all --no-ui --force --filter "build-tools-24.0.2"; fi;
     - if [ ! -e /usr/local/android-sdk-linux/platforms/android-24 ]; then echo y | android update sdk --all --no-ui --force --filter "android-24"; fi;
-    - if [ ! -e /usr/local/android-sdk-linux/extras/android/m2repository ]; then echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository"; fi;
+    - if ! $(grep -q "Revision=41.0.0" $ANDROID_HOME/extras/android/m2repository/source.properties); then echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository"; fi;
   cache_directories:
     - /usr/local/android-sdk-linux/build-tools/24.0.2
     - /usr/local/android-sdk-linux/platforms/android-24

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
 
 test:
   override:
-    - ./gradlew --refresh-dependencies
+    - ./gradlew
 
 deployment:
   master:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-version=[B2.2.0-SNAPSHOT
+version=2.2.0-SNAPSHOT
 
 GROUP=com.mapzen.android
-VERSION_NAME=[B2.2.0-SNAPSHOT
+VERSION_NAME=2.2.0-SNAPSHOT
 
 POM_URL=http://github.com/mapzen/lost
 POM_SCM_URL=http://github.com/mapzen/lost

--- a/lost/src/test/java/com/mapzen/android/lost/BaseRobolectricTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/BaseRobolectricTest.java
@@ -1,0 +1,48 @@
+package com.mapzen.android.lost;
+
+import org.junit.After;
+import org.robolectric.util.ReflectionHelpers;
+
+import android.annotation.SuppressLint;
+import android.util.ArraySet;
+import android.view.View;
+
+import java.util.ArrayList;
+
+/**
+ * Base test class to cleanup Robolectric window manager memory leak.
+ *
+ * https://github.com/robolectric/robolectric/issues/2068
+ */
+public class BaseRobolectricTest {
+  @After @SuppressLint("NewApi") public void resetWindowManager() {
+    try {
+      Class clazz = ReflectionHelpers.loadClass(getClass().getClassLoader(),
+          "android.view.WindowManagerGlobal");
+      Object instance = ReflectionHelpers.callStaticMethod(clazz, "getInstance");
+
+      // We essentially duplicate what's in {@link WindowManagerGlobal#closeAll} with what's below.
+      // The closeAll method has a bit of a bug where it's iterating through the "roots" but
+      // bases the number of objects to iterate through by the number of "views." This can result in
+      // an {@link java.lang.IndexOutOfBoundsException} being thrown.
+      Object lock = ReflectionHelpers.getField(instance, "mLock");
+
+      ArrayList<Object> roots = ReflectionHelpers.getField(instance, "mRoots");
+      //noinspection SynchronizationOnLocalVariableOrMethodParameter
+      synchronized (lock) {
+        for (int i = 0; i < roots.size(); i++) {
+          ReflectionHelpers.callInstanceMethod(instance, "removeViewLocked",
+              ReflectionHelpers.ClassParameter.from(int.class, i),
+              ReflectionHelpers.ClassParameter.from(boolean.class, false));
+        }
+      }
+
+      // Views will still be held by this array. We need to clear it out to ensure
+      // everything is released.
+      ArraySet<View> dyingViews = ReflectionHelpers.getField(instance, "mDyingViews");
+      dyingViews.clear();
+    } catch (Exception e) {
+      // Catch ClassNotFoundException for API levels where WindowManagerGlobal doesn't exits.
+    }
+  }
+}

--- a/lost/src/test/java/com/mapzen/android/lost/api/LocationRequestTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/api/LocationRequestTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.lost.api;
 
+import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.lost.BuildConfig;
 
 import org.junit.Before;
@@ -14,7 +15,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
-public class LocationRequestTest {
+public class LocationRequestTest extends BaseRobolectricTest {
   private LocationRequest locationRequest;
 
   @Before public void setUp() throws Exception {

--- a/lost/src/test/java/com/mapzen/android/lost/api/LocationResultTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/api/LocationResultTest.java
@@ -1,8 +1,12 @@
 package com.mapzen.android.lost.api;
 
+import com.mapzen.android.lost.BaseRobolectricTest;
+import com.mapzen.lost.BuildConfig;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import android.content.Intent;
 import android.location.Location;
@@ -15,7 +19,9 @@ import static org.fest.assertions.api.Assertions.assertThat;
 /**
  * {@link LocationResult} test class.
  */
-@RunWith(RobolectricTestRunner.class) public class LocationResultTest {
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
+public class LocationResultTest extends BaseRobolectricTest {
 
   @Test public void shouldNotBeNull() throws Exception {
     assertThat(LocationResult.create(null)).isNotNull();

--- a/lost/src/test/java/com/mapzen/android/lost/api/LocationServicesTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/api/LocationServicesTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.lost.api;
 
+import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.android.lost.internal.FusedLocationProviderApiImpl;
 import com.mapzen.android.lost.internal.GeofencingApiImpl;
 import com.mapzen.android.lost.internal.SettingsApiImpl;
@@ -14,7 +15,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
-public class LocationServicesTest {
+public class LocationServicesTest extends BaseRobolectricTest {
 
   @Test public void shouldCreateFusedLocationProviderApiImpl() throws Exception {
     assertThat(LocationServices.FusedLocationApi).isInstanceOf(FusedLocationProviderApiImpl.class);

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LostApiClient;
@@ -35,7 +36,7 @@ import static org.robolectric.Shadows.shadowOf;
 @RunWith(RobolectricTestRunner.class)
 @SuppressWarnings("MissingPermission")
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
-public class FusedLocationProviderApiImplTest {
+public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
 
   private LostApiClient client;
   private LostApiClient secondClient;

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.android.lost.api.LocationAvailability;
 import com.mapzen.android.lost.api.LocationCallback;
 import com.mapzen.android.lost.api.LocationListener;
@@ -56,7 +57,7 @@ import static org.robolectric.Shadows.shadowOf;
 @SuppressWarnings("MissingPermission")
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE, shadows = {
         LostShadowLocationManager.class})
-public class FusedLocationProviderServiceImplTest {
+public class FusedLocationProviderServiceImplTest extends BaseRobolectricTest {
   private LostApiClient client;
   private FusedLocationProviderServiceImpl api;
   private LocationManager locationManager;

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusionEngineTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusionEngineTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.lost.BuildConfig;
 
@@ -38,7 +39,7 @@ import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
-public class FusionEngineTest {
+public class FusionEngineTest extends BaseRobolectricTest {
   private FusionEngine fusionEngine;
   private TestCallback callback;
   private LocationManager locationManager;

--- a/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingIntentSenderTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/GeofencingIntentSenderTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.android.lost.api.Geofence;
 import com.mapzen.android.lost.api.GeofencingApi;
 import com.mapzen.android.lost.api.GeofencingIntentSender;
@@ -27,7 +28,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("MissingPermission")
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
-public class GeofencingIntentSenderTest {
+public class GeofencingIntentSenderTest extends BaseRobolectricTest {
 
   GeofencingIntentSender intentSender;
   GeofencingApiImpl geofencingApi;

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.android.lost.api.LocationListener;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LocationServices;
@@ -26,7 +27,7 @@ import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
-public class LostApiClientImplTest {
+public class LostApiClientImplTest extends BaseRobolectricTest {
   private LostApiClient client;
   private TestConnectionCallbacks callbacks;
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostClientManagerTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostClientManagerTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.android.lost.api.LocationAvailability;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LocationResult;
@@ -28,7 +29,7 @@ import static org.robolectric.RuntimeEnvironment.application;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
-public class LostClientManagerTest {
+public class LostClientManagerTest extends BaseRobolectricTest {
 
   ClientManager manager = LostClientManager.shared();
   Context context = mock(Context.class);

--- a/lost/src/test/java/com/mapzen/android/lost/internal/MockEngineTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/MockEngineTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.lost.BuildConfig;
 
@@ -26,7 +27,7 @@ import static org.robolectric.RuntimeEnvironment.application;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
-public class MockEngineTest {
+public class MockEngineTest extends BaseRobolectricTest {
   private MockEngine mockEngine;
   private TestCallback callback;
   private TestTraceThreadFactory traceThreadFactory;

--- a/lost/src/test/java/com/mapzen/android/lost/internal/SystemClockTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/SystemClockTest.java
@@ -1,5 +1,7 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.lost.BuildConfig;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -10,7 +12,9 @@ import android.location.Location;
 import static com.mapzen.android.lost.internal.SystemClock.MS_TO_NS;
 import static org.fest.assertions.api.Assertions.assertThat;
 
-@RunWith(RobolectricTestRunner.class) public class SystemClockTest {
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
+public class SystemClockTest {
   @Test @Config(sdk = 17) public void getTimeInNanos_shouldReturnElapsedRealtimeNanosForSdk17AndUp()
       throws Exception {
     final long nanos = 1000000;

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TraceThreadTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TraceThreadTest.java
@@ -1,5 +1,8 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.BaseRobolectricTest;
+import com.mapzen.lost.BuildConfig;
+
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
@@ -7,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowEnvironment;
 
 import android.location.Location;
@@ -20,7 +24,9 @@ import java.util.ArrayList;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.RuntimeEnvironment.application;
 
-@RunWith(RobolectricTestRunner.class) public class TraceThreadTest {
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
+public class TraceThreadTest extends BaseRobolectricTest {
   private TestMockEngine mockEngine;
   private TestSleepFactory sleepFactory;
   private TraceThread traceThread;


### PR DESCRIPTION
### Overview

Caches build tools, platform, and android m2 repo folders on Circle CI. Implment build and test  optimizations.

### Proposed Changes

Adds logic to `circle.yml` to download Android SDK components only if the folder is not already cached. Also specifies which directories should be cached and restored at the beginning of each build.

Lost build on Circle CI has been reduced from ~9 minutes to less than 5 minutes by taking the following measures:

* Cache Android SDK components
* Removing `--refresh-dependencies` from build commands
* [Disabling pre dex](http://www.littlerobots.nl/blog/disable-android-pre-dexing-on-ci-builds/) on Circle CI builds
* Adds BaseRobolectric test to [clean up global window manager memory leaks and shutdown background threads](https://github.com/robolectric/robolectric/issues/2068).