### PR TITLE
Fixes ConcurrentModificationException when client is disconnected on connect

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
@@ -6,6 +6,7 @@ import com.mapzen.android.lost.api.LostApiClient.ConnectionCallbacks;
 import android.content.Context;
 import android.os.IBinder;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -80,7 +81,7 @@ public class FusedLocationServiceConnectionManager {
       }
 
       if (!connectionCallbacks.isEmpty()) {
-        final Set<ConnectionCallbacks> copy = new HashSet<>(connectionCallbacks);
+        final ArrayList<ConnectionCallbacks> copy = new ArrayList<>(connectionCallbacks);
         for (LostApiClient.ConnectionCallbacks callbacks : copy) {
           callbacks.onConnected();
         }
@@ -92,7 +93,7 @@ public class FusedLocationServiceConnectionManager {
     if (connectState != ConnectState.IDLE) {
       connectState = ConnectState.IDLE;
       if (!connectionCallbacks.isEmpty()) {
-        final Set<ConnectionCallbacks> copy = new HashSet<>(connectionCallbacks);
+        final ArrayList<ConnectionCallbacks> copy = new ArrayList<>(connectionCallbacks);
         for (LostApiClient.ConnectionCallbacks callbacks : copy) {
           callbacks.onConnectionSuspended();
         }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManager.java
@@ -80,7 +80,8 @@ public class FusedLocationServiceConnectionManager {
       }
 
       if (!connectionCallbacks.isEmpty()) {
-        for (LostApiClient.ConnectionCallbacks callbacks : connectionCallbacks) {
+        final Set<ConnectionCallbacks> copy = new HashSet<>(connectionCallbacks);
+        for (LostApiClient.ConnectionCallbacks callbacks : copy) {
           callbacks.onConnected();
         }
       }
@@ -91,7 +92,8 @@ public class FusedLocationServiceConnectionManager {
     if (connectState != ConnectState.IDLE) {
       connectState = ConnectState.IDLE;
       if (!connectionCallbacks.isEmpty()) {
-        for (LostApiClient.ConnectionCallbacks callbacks : connectionCallbacks) {
+        final Set<ConnectionCallbacks> copy = new HashSet<>(connectionCallbacks);
+        for (LostApiClient.ConnectionCallbacks callbacks : copy) {
           callbacks.onConnectionSuspended();
         }
       }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManagerTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationServiceConnectionManagerTest.java
@@ -165,6 +165,15 @@ public class FusedLocationServiceConnectionManagerTest {
     assertThat(eventCallbacks.connectedOnServiceConnected).isTrue();
   }
 
+  @Test public void onServiceConnected_shouldHandleCallbacksRemovedOnConnect() throws Exception {
+    LostApiClient.ConnectionCallbacks connectionCallbacks1 = new RemoveOnConnected();
+    LostApiClient.ConnectionCallbacks connectionCallbacks2 = new RemoveOnConnected();
+    connectionManager.connect(null, connectionCallbacks1);
+    connectionManager.addCallbacks(connectionCallbacks2);
+    connectionManager.onServiceConnected(null);
+    assertThat(connectionManager.getConnectionCallbacks()).isEmpty();
+  }
+
   @Test public void onServiceDisconnected_shouldCallConnectionCallback() {
     TestConnectionCallbacks connectionCallbacks = new TestConnectionCallbacks();
     connectionManager.connect(null, connectionCallbacks);
@@ -192,6 +201,15 @@ public class FusedLocationServiceConnectionManagerTest {
     connectionCallbacks.onConnected();
     connectionManager.onServiceDisconnected();
     assertThat(connectionCallbacks.isConnected()).isTrue();
+  }
+
+  @Test public void onServiceDisconnected_shouldHandleCallbacksRemovedOnSuspend() throws Exception {
+    LostApiClient.ConnectionCallbacks connectionCallbacks1 = new RemoveOnSuspended();
+    LostApiClient.ConnectionCallbacks connectionCallbacks2 = new RemoveOnSuspended();
+    connectionManager.connect(null, connectionCallbacks1);
+    connectionManager.addCallbacks(connectionCallbacks2);
+    connectionManager.onServiceDisconnected();
+    assertThat(connectionManager.getConnectionCallbacks()).isEmpty();
   }
 
   class TestEventCallbacks implements FusedLocationServiceConnectionManager.EventCallbacks {
@@ -229,6 +247,24 @@ public class FusedLocationServiceConnectionManagerTest {
     public void onDisconnect() {
       connected = false;
       idleOnDisconnect = !connectionManager.isConnected() && !connectionManager.isConnecting();
+    }
+  }
+
+  private class RemoveOnConnected implements LostApiClient.ConnectionCallbacks {
+    @Override public void onConnected() {
+      connectionManager.removeCallbacks(this);
+    }
+
+    @Override public void onConnectionSuspended() {
+    }
+  }
+
+  private class RemoveOnSuspended implements LostApiClient.ConnectionCallbacks {
+    @Override public void onConnected() {
+    }
+
+    @Override public void onConnectionSuspended() {
+      connectionManager.removeCallbacks(this);
     }
   }
 }


### PR DESCRIPTION
### Overview

Fixes `ConcurrentModificationException` when multiple clients exist and one client is disconnected on connect.

### Proposed Changes

Iterates a over copy of the connection callbacks set stored in the `FusedLocationServiceConnectionManager` when the fused location service is either connected or suspended. This prevent a `ConcurrentModificationException` if callbacks are removed during iteration.

Fixes #162