### PR TITLE
Store all connection callbacks in the service manager

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
@@ -37,6 +37,7 @@ public class LostApiClientImpl implements LostApiClient {
     if (fusedApi.isConnected()) {
       if (connectionCallbacks != null) {
         connectionCallbacks.onConnected();
+        fusedApi.addConnectionCallbacks(connectionCallbacks);
       }
     } else if (fusedApi.isConnecting()) {
       if (connectionCallbacks != null) {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -44,6 +44,10 @@ public class LostApiClientImplTest extends BaseRobolectricTest {
 
   @After public void tearDown() throws Exception {
     client.disconnect();
+    ((FusedLocationProviderApiImpl) LocationServices.FusedLocationApi)
+        .getServiceConnectionManager()
+        .getConnectionCallbacks()
+        .clear();
   }
 
   @Test public void connect_shouldConnectFusedLocationProviderApiImpl() throws Exception {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -82,6 +82,26 @@ public class LostApiClientImplTest extends BaseRobolectricTest {
     assertThat(callbacks.isClientConnectedOnConnect()).isTrue();
   }
 
+  @Test public void connect_shouldAddConnectionCallbacks() throws Exception {
+    // Connect first Lost client with connection callbacks.
+    new LostApiClientImpl(application, new LostApiClient.ConnectionCallbacks() {
+      @Override public void onConnected() {
+        // Connect second Lost client with new connection callbacks once the service has connected.
+        new LostApiClientImpl(application,  new TestConnectionCallbacks(),
+            new LostClientManager()).connect();
+      }
+
+      @Override public void onConnectionSuspended() {
+      }
+    }, new LostClientManager()).connect();
+
+    FusedLocationProviderApiImpl api =
+        (FusedLocationProviderApiImpl) LocationServices.FusedLocationApi;
+
+    // Verify both sets of connection callbacks have been stored in the service connection manager.
+    assertThat(api.getServiceConnectionManager().getConnectionCallbacks()).hasSize(2);
+  }
+
   @Test public void disconnect_shouldNotRemoveFusedLocationProviderApiImpl() throws Exception {
     client.connect();
     client.disconnect();


### PR DESCRIPTION
### Overview

Store all connection callbacks in service manager even if the service is already connected.

### Proposed Changes

In `LostApiClientImpl.connect()` all connection callbacks should be added to the `FusedLocationApiImpl` even if the `isConnected()` returns true.

This ensures if the service is later suspended and re-connected the appropriate callbacks will be invoked for all instances of `LostApiClient`.

Fixes #164 