### PR TITLE
Verify client is connected

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,5 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=Mapzen
 POM_DEVELOPER_NAME=Mapzen
+
+org.gradle.jvmargs=-Xmx1536m

--- a/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerMultipleClientsActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerMultipleClientsActivity.java
@@ -73,7 +73,6 @@ public class MultipleLocationListenerMultipleClientsActivity extends ListActivit
     super.onStop();
     LocationServices.FusedLocationApi.removeLocationUpdates(lostApiClient,
         MultipleLocationListenerMultipleClientsActivity.this);
-    fragment.removeLocationUpdates();
     lostApiClient.disconnect();
   }
 
@@ -145,12 +144,9 @@ public class MultipleLocationListenerMultipleClientsActivity extends ListActivit
       fragmentClient.connect();
     }
 
-    public void removeLocationUpdates() {
-      LocationServices.FusedLocationApi.removeLocationUpdates(fragmentClient, this);
-    }
-
     @Override public void onStop() {
       super.onStop();
+      LocationServices.FusedLocationApi.removeLocationUpdates(fragmentClient, this);
       fragmentClient.disconnect();
     }
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -127,27 +127,33 @@ public interface FusedLocationProviderApi {
   /**
    * Removes location updates for the {@link LocationListener}
    *
-   * @param client Client which registered the listener.
+   * @param client Client which registered the listener. The client must be connected at the time
+   * of this call.
    * @param listener Listener to remove updates for.
    * @return a {@link PendingResult} for the call to check whether call was successful.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   PendingResult<Status> removeLocationUpdates(LostApiClient client, LocationListener listener);
 
   /**
    * Removes location updates for the {@link PendingIntent}
    *
-   * @param client Client which registered the listener.
+   * @param client Client which registered the pending intent. The client must be connected at the
+   * time of this call.
    * @param callbackIntent Intent to remove updates for.
    * @return a {@link PendingResult} for the call to check whether call was successful.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   PendingResult<Status> removeLocationUpdates(LostApiClient client, PendingIntent callbackIntent);
 
   /**
    * Remove location updates for the {@link LocationCallback}
    *
-   * @param client Client which registered the listener.
+   * @param client Client which registered the location callback. The client must be connected at
+   * the time of this call.
    * @param callback Callback to remove updates for.
    * @return a {@link PendingResult} for the call to check whether call was successful.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   PendingResult<Status> removeLocationUpdates(LostApiClient client, LocationCallback callback);
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -57,6 +57,7 @@ public interface FusedLocationProviderApi {
    * @param request Specifies desired location accuracy, update interval, etc.
    * @param listener Listener to make calls on when location becomes available.
    * @return a {@link PendingResult} for the call to check whether call was successful.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
@@ -76,6 +77,7 @@ public interface FusedLocationProviderApi {
    * @param listener Listener to make calls on when location becomes available.
    * @param looper Looper to implement the listener callbacks on.
    * @return a {@link PendingResult} for the call to check whether call was successful.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
@@ -95,6 +97,7 @@ public interface FusedLocationProviderApi {
    * @param callback Callback to make calls on when location becomes available.
    * @param looper Looper to implement the listener callbacks on.
    * @return a {@link PendingResult} for the call to check whether call was successful.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
@@ -119,6 +122,7 @@ public interface FusedLocationProviderApi {
    * @param request Specifies desired location accuracy, update interval, etc.
    * @param callbackIntent Intent to be sent for each location update.
    * @return a {@link PendingResult} for the call to check whether call was successful.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -25,6 +25,7 @@ public interface FusedLocationProviderApi {
    * The best accuracy available while respecting the location permissions will be returned.
    * @param client The client to return location for.
    * @return The best, most recent location available.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   Location getLastLocation(LostApiClient client);
@@ -40,6 +41,7 @@ public interface FusedLocationProviderApi {
    *
    * @param client The client to return availability for.
    * @return The availability of location data.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   LocationAvailability getLocationAvailability(LostApiClient client);

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -174,6 +174,7 @@ public interface FusedLocationProviderApi {
    * @param client Connected client.
    * @param isMockMode Whether mock mode should be enabled or not.
    * @return a {@link PendingResult} for the call to check whether call was successful.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   PendingResult<Status> setMockMode(LostApiClient client, boolean isMockMode);
 
@@ -185,6 +186,7 @@ public interface FusedLocationProviderApi {
    * @param client Connected client.
    * @param mockLocation Location to be set for the location provider.
    * @return a {@link PendingResult} for the call to check whether call was successful.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   PendingResult<Status> setMockLocation(LostApiClient client, Location mockLocation);
 
@@ -196,6 +198,7 @@ public interface FusedLocationProviderApi {
    * @param client Connected client.
    * @param file GPX file to be used to report location.
    * @return a {@link PendingResult} for the call to check whether call was successful.
+   * @throws IllegalStateException if the client is not connected at the time of this call.
    */
   PendingResult<Status> setMockTrace(LostApiClient client, final File file);
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -127,16 +127,25 @@ public class FusedLocationProviderApiImpl
 
   @Override public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       LocationListener listener) {
+    if (!client.isConnected()) {
+      throw new IllegalStateException("LostApiClient is not connected.");
+    }
     return service.removeLocationUpdates(client, listener);
   }
 
   @Override public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       PendingIntent callbackIntent) {
+    if (!client.isConnected()) {
+      throw new IllegalStateException("LostApiClient is not connected.");
+    }
     return service.removeLocationUpdates(client, callbackIntent);
   }
 
   @Override public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       LocationCallback callback) {
+    if (!client.isConnected()) {
+      throw new IllegalStateException("LostApiClient is not connected.");
+    }
     return service.removeLocationUpdates(client, callback);
   }
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -97,10 +97,12 @@ public class FusedLocationProviderApiImpl
   }
 
   @Override public Location getLastLocation(LostApiClient client) {
+    throwIfNotConnected(client);
     return service.getLastLocation(client);
   }
 
   @Override public LocationAvailability getLocationAvailability(LostApiClient client) {
+    throwIfNotConnected(client);
     return service.getLocationAvailability(client);
   }
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -106,6 +106,7 @@ public class FusedLocationProviderApiImpl
 
   @Override public PendingResult<Status> requestLocationUpdates(LostApiClient client,
       LocationRequest request, LocationListener listener) {
+    throwIfNotConnected(client);
     return service.requestLocationUpdates(client, request, listener);
   }
 
@@ -116,36 +117,32 @@ public class FusedLocationProviderApiImpl
 
   @Override public PendingResult<Status> requestLocationUpdates(LostApiClient client,
       LocationRequest request, LocationCallback callback, Looper looper) {
+    throwIfNotConnected(client);
     return service.requestLocationUpdates(client, request, callback, looper);
   }
 
   @Override
   public PendingResult<Status> requestLocationUpdates(LostApiClient client, LocationRequest request,
       PendingIntent callbackIntent) {
+    throwIfNotConnected(client);
     return service.requestLocationUpdates(client, request, callbackIntent);
   }
 
   @Override public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       LocationListener listener) {
-    if (!client.isConnected()) {
-      throw new IllegalStateException("LostApiClient is not connected.");
-    }
+    throwIfNotConnected(client);
     return service.removeLocationUpdates(client, listener);
   }
 
   @Override public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       PendingIntent callbackIntent) {
-    if (!client.isConnected()) {
-      throw new IllegalStateException("LostApiClient is not connected.");
-    }
+    throwIfNotConnected(client);
     return service.removeLocationUpdates(client, callbackIntent);
   }
 
   @Override public PendingResult<Status> removeLocationUpdates(LostApiClient client,
       LocationCallback callback) {
-    if (!client.isConnected()) {
-      throw new IllegalStateException("LostApiClient is not connected.");
-    }
+    throwIfNotConnected(client);
     return service.removeLocationUpdates(client, callback);
   }
 
@@ -180,5 +177,11 @@ public class FusedLocationProviderApiImpl
 
   FusedLocationServiceConnectionManager getServiceConnectionManager() {
     return serviceConnectionManager;
+  }
+
+  private void throwIfNotConnected(LostApiClient client) {
+    if (!client.isConnected()) {
+      throw new IllegalStateException("LostApiClient is not connected.");
+    }
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -149,15 +149,18 @@ public class FusedLocationProviderApiImpl
   }
 
   @Override public PendingResult<Status> setMockMode(LostApiClient client, boolean isMockMode) {
+    throwIfNotConnected(client);
     return service.setMockMode(client, isMockMode);
   }
 
   @Override public PendingResult<Status> setMockLocation(LostApiClient client,
       Location mockLocation) {
+    throwIfNotConnected(client);
     return service.setMockLocation(client, mockLocation);
   }
 
   @Override public PendingResult<Status> setMockTrace(LostApiClient client, File file) {
+    throwIfNotConnected(client);
     return service.setMockTrace(client, file);
   }
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -139,22 +139,64 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
     verify(service).requestLocationUpdates(client, request, callback, looper);
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void removeLocationUpdates_listener_shouldThrowIfNotConnected() throws Exception {
+    client.disconnect();
+    api.removeLocationUpdates(client, new TestLocationListener());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void removeLocationUpdates_pendingIntent_shouldThrowIfNotConnected() throws Exception {
+    client.disconnect();
+    api.removeLocationUpdates(client, mock(PendingIntent.class));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void removeLocationUpdates_callback_shouldThrowIfNotConnected() throws Exception {
+    client.disconnect();
+    api.removeLocationUpdates(client, new TestLocationCallback());
+  }
+
   @Test public void removeLocationUpdates_listener_shouldCallService() {
-    LocationListener listener = new TestLocationListener();
-    api.removeLocationUpdates(client, listener);
-    verify(service).removeLocationUpdates(client, listener);
+    new LostApiClient.Builder(mock(Context.class))
+        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
+          @Override public void onConnected() {
+            LocationListener listener = new TestLocationListener();
+            api.removeLocationUpdates(client, listener);
+            verify(service).removeLocationUpdates(client, listener);
+          }
+
+          @Override public void onConnectionSuspended() {
+          }
+        }).build().connect();
   }
 
   @Test public void removeLocationUpdates_pendingIntent_shouldCallService() {
-    PendingIntent callbackIntent = mock(PendingIntent.class);
-    api.removeLocationUpdates(client, callbackIntent);
-    verify(service).removeLocationUpdates(client, callbackIntent);
+    new LostApiClient.Builder(mock(Context.class))
+        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
+          @Override public void onConnected() {
+            PendingIntent callbackIntent = mock(PendingIntent.class);
+            api.removeLocationUpdates(client, callbackIntent);
+            verify(service).removeLocationUpdates(client, callbackIntent);
+          }
+
+          @Override public void onConnectionSuspended() {
+          }
+        }).build().connect();
   }
 
   @Test public void removeLocationUpdates_callback_shouldCallService() {
-    TestLocationCallback callback = new TestLocationCallback();
-    service.removeLocationUpdates(client, callback);
-    verify(service).removeLocationUpdates(client, callback);
+    new LostApiClient.Builder(mock(Context.class))
+        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
+          @Override public void onConnected() {
+            TestLocationCallback callback = new TestLocationCallback();
+            api.removeLocationUpdates(client, callback);
+            verify(service).removeLocationUpdates(client, callback);
+          }
+
+          @Override public void onConnectionSuspended() {
+          }
+        }).build().connect();
   }
 
   @Test public void setMockMode_shouldCallService() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -154,7 +154,7 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
   @Test(expected = IllegalStateException.class)
   public void requestLocationUpdates_pendingIntent_shouldThrowIfNotConnected() throws Exception {
     client.disconnect();
-    api.requestLocationUpdates(client, LocationRequest.create(),mock(PendingIntent.class));
+    api.requestLocationUpdates(client, LocationRequest.create(), mock(PendingIntent.class));
   }
 
   @Test(expected = IllegalStateException.class)

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -277,21 +277,63 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
         }).build().connect();
   }
 
-  @Test public void setMockMode_shouldCallService() {
+  @Test(expected = IllegalStateException.class)
+  public void setMockMode_shouldThrowIfNotConnected() throws Exception {
+    client.disconnect();
     api.setMockMode(client, true);
-    verify(service).setMockMode(client, true);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void setMockLocation_shouldThrowIfNotConnected() throws Exception {
+    client.disconnect();
+    api.setMockLocation(client, new Location("test"));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void setMockTrace_shouldThrowIfNotConnected() throws Exception {
+    client.disconnect();
+    api.setMockTrace(client, new File("path", "name"));
+  }
+
+  @Test public void setMockMode_shouldCallService() {
+    new LostApiClient.Builder(mock(Context.class))
+        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
+          @Override public void onConnected() {
+            api.setMockMode(client, true);
+            verify(service).setMockMode(client, true);
+          }
+
+          @Override public void onConnectionSuspended() {
+          }
+        }).build().connect();
   }
 
   @Test public void setMockLocation_shouldCallService() {
-    Location location = new Location("test");
-    api.setMockLocation(client, location);
-    verify(service).setMockLocation(client, location);
+    new LostApiClient.Builder(mock(Context.class))
+        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
+          @Override public void onConnected() {
+            Location location = new Location("test");
+            api.setMockLocation(client, location);
+            verify(service).setMockLocation(client, location);
+          }
+
+          @Override public void onConnectionSuspended() {
+          }
+        }).build().connect();
   }
 
   @Test public void setMockTrace_shouldCallService() {
-    File file = new File("path", "name");
-    api.setMockTrace(client, file);
-    verify(service).setMockTrace(client, file);
+    new LostApiClient.Builder(mock(Context.class))
+        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
+          @Override public void onConnected() {
+            File file = new File("path", "name");
+            api.setMockTrace(client, file);
+            verify(service).setMockTrace(client, file);
+          }
+
+          @Override public void onConnectionSuspended() {
+          }
+        }).build().connect();
   }
 
   @Test public void isProviderEnabled_shouldCallService() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -107,14 +107,42 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
     verify(connectionManager).isConnected();
   }
 
-  @Test public void getLastLocation_shouldCallService() {
+  @Test(expected = IllegalStateException.class)
+  public void getLastLocation_shouldThrowIfNotConnected() throws Exception {
+    client.disconnect();
     api.getLastLocation(client);
-    verify(service).getLastLocation(client);
+  }
+
+  @Test public void getLastLocation_shouldCallService() {
+    new LostApiClient.Builder(mock(Context.class))
+        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
+          @Override public void onConnected() {
+            api.getLastLocation(client);
+            verify(service).getLastLocation(client);
+          }
+
+          @Override public void onConnectionSuspended() {
+          }
+        }).build().connect();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void getLocationAvailability_shouldThrowIfNotConnected() throws Exception {
+    client.disconnect();
+    api.getLocationAvailability(client);
   }
 
   @Test public void getLocationAvailability_shouldCallService() {
-    api.getLocationAvailability(client);
-    verify(service).getLocationAvailability(client);
+    new LostApiClient.Builder(mock(Context.class))
+        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
+          @Override public void onConnected() {
+            api.getLocationAvailability(client);
+            verify(service).getLocationAvailability(client);
+          }
+
+          @Override public void onConnectionSuspended() {
+          }
+        }).build().connect();
   }
 
   @Test(expected = IllegalStateException.class)

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -44,6 +44,10 @@ public class LostApiClientImplTest extends BaseRobolectricTest {
 
   @After public void tearDown() throws Exception {
     client.disconnect();
+    ((FusedLocationProviderApiImpl) LocationServices.FusedLocationApi)
+        .getServiceConnectionManager()
+        .getConnectionCallbacks()
+        .clear();
   }
 
   @Test public void connect_shouldConnectFusedLocationProviderApiImpl() throws Exception {


### PR DESCRIPTION
### Overview

`FusedLocationProviderApi` should throw an exception if the client instance passed into any of its methods is not currently connected.

### Proposed Changes

Updates methods, tests, and documentation to throw an `IllegalStateException` if the `LostApiClient` used is not connected.

Also fixes a crash when exiting the multiple client demo activity due to removing location updates after the fragment client has been disconnected.

Fixes #166 