### PR TITLE
GPS feature should not be required to use Lost

### DIFF
--- a/lost/src/main/AndroidManifest.xml
+++ b/lost/src/main/AndroidManifest.xml
@@ -6,7 +6,9 @@
       android:name="android.hardware.sensor.accelerometer"
       android:required="false"/>
   <uses-feature android:name="android.hardware.location"/>
-  <uses-feature android:name="android.hardware.location.gps"/>
+  <uses-feature
+      android:name="android.hardware.location.gps"
+      android:required="false"/>
   <uses-feature
       android:name="android.hardware.telephony"
       android:required="false"/>


### PR DESCRIPTION
### Overview

GPS sensor should not be required to use Lost.

### Proposed Changes

Updates `AndroidManifest.xml` to set `required=false` for `android.hardware.location.gps` feature.

Closes #169 