### PR TITLE
Removes deprecated location listener callbacks for provider enabled/disabled

### DIFF
--- a/lost-sample/src/main/java/com/example/lost/LocationListenerActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/LocationListenerActivity.java
@@ -49,14 +49,6 @@ public class LocationListenerActivity extends AppCompatActivity  implements
     @Override public void onLocationChanged(Location location) {
       fragment.updateLocation(location);
     }
-
-    @Override public void onProviderDisabled(String provider) {
-      Log.d(TAG, "Location provider disabled: " + provider);
-    }
-
-    @Override public void onProviderEnabled(String provider) {
-      Log.d(TAG, "Location provider enabled: " + provider);
-    }
   };
 
   @Override protected void onCreate(Bundle savedInstanceState) {

--- a/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerMultipleClientsActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerMultipleClientsActivity.java
@@ -85,7 +85,7 @@ public class MultipleLocationListenerMultipleClientsActivity extends ListActivit
       return;
     }
 
-    long interval = 3 * 60 * 1000; // 3 minutes
+    long interval = 30 * 1000; // 30 seconds
     LocationRequest request = LocationRequest.create()
         .setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY)
         .setFastestInterval(interval)
@@ -158,7 +158,7 @@ public class MultipleLocationListenerMultipleClientsActivity extends ListActivit
         return;
       }
 
-      long interval = 30 * 1000; // 30 sec
+      long interval = 15 * 1000; // 15 seconds
       LocationRequest request = LocationRequest.create()
           .setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY)
           .setFastestInterval(interval)

--- a/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerMultipleClientsActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerMultipleClientsActivity.java
@@ -98,14 +98,6 @@ public class MultipleLocationListenerMultipleClientsActivity extends ListActivit
     addItem("Activity");
   }
 
-  @Override public void onProviderDisabled(String provider) {
-
-  }
-
-  @Override public void onProviderEnabled(String provider) {
-
-  }
-
   public void addItem(String title) {
     Date date = new Date(System.currentTimeMillis());
     SimpleDateFormat dateformat = new SimpleDateFormat("HH:mm:ss");
@@ -172,14 +164,5 @@ public class MultipleLocationListenerMultipleClientsActivity extends ListActivit
           (MultipleLocationListenerMultipleClientsActivity) getActivity();
       a.addItem("Fragment");
     }
-
-    @Override public void onProviderDisabled(String provider) {
-
-    }
-
-    @Override public void onProviderEnabled(String provider) {
-
-    }
   }
-
 }

--- a/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerSingleClientActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerSingleClientActivity.java
@@ -31,27 +31,11 @@ public class MultipleLocationListenerSingleClientActivity extends ListActivity {
     @Override public void onLocationChanged(Location location) {
       addItem("Listener");
     }
-
-    @Override public void onProviderDisabled(String provider) {
-
-    }
-
-    @Override public void onProviderEnabled(String provider) {
-
-    }
   };
 
   LocationListener otherListener = new LocationListener() {
     @Override public void onLocationChanged(Location location) {
       addItem("Other Listener");
-    }
-
-    @Override public void onProviderDisabled(String provider) {
-
-    }
-
-    @Override public void onProviderEnabled(String provider) {
-
     }
   };
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationListener.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationListener.java
@@ -15,30 +15,4 @@ public interface LocationListener {
    * @param location the newest location.
    */
   void onLocationChanged(Location location);
-
-  /**
-   * Called when a location provider is disabled. You will only receive updates for the priority
-   * level set in the location request used to register for updates in
-   * {@link FusedLocationProviderApi#requestLocationUpdates(LostApiClient, LocationRequest,
-   * LocationListener)}. Ie. {@link LocationRequest#PRIORITY_HIGH_ACCURACY} will invoke this method
-   * for gps and network changes but {@link LocationRequest#PRIORITY_BALANCED_POWER_ACCURACY} will
-   * only invoke it for network changes. This method will be removed in the next major release, it
-   * is recommended that you use {@link LocationAvailability} instead.
-   * @param provider the disabled provider.
-   */
-  @Deprecated
-  void onProviderDisabled(String provider);
-
-  /**
-   * Called when a location provider is enabled. You will only receive updates for the priority
-   * level set in the location request used to register for updates in
-   * {@link FusedLocationProviderApi#requestLocationUpdates(LostApiClient, LocationRequest,
-   * LocationListener)}. Ie. {@link LocationRequest#PRIORITY_HIGH_ACCURACY} will invoke this method
-   * for gps and network changes but {@link LocationRequest#PRIORITY_BALANCED_POWER_ACCURACY} will
-   * only invoke it for network changes. This method will be removed in the next major release, it
-   * is recommended that you use {@link LocationAvailability} instead.
-   * @param provider the enabled provider.
-   */
-  @Deprecated
-  void onProviderEnabled(String provider);
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
@@ -39,8 +39,6 @@ public interface ClientManager {
       LocationAvailability availability, LocationResult result);
   ReportedChanges reportLocationResult(Location location, final LocationResult result);
   void updateReportedValues(ReportedChanges changes);
-  void reportProviderEnabled(String provider);
-  void reportProviderDisabled(String provider);
   void notifyLocationAvailability(final LocationAvailability availability);
   boolean hasNoListeners();
   Map<LostApiClient, Set<LocationListener>> getLocationListeners();

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImpl.java
@@ -137,13 +137,11 @@ public class FusedLocationProviderServiceImpl implements LocationEngine.Callback
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   public void reportProviderDisabled(String provider) {
-    clientManager.reportProviderDisabled(provider);
     notifyLocationAvailabilityChanged();
   }
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   public void reportProviderEnabled(String provider) {
-    clientManager.reportProviderEnabled(provider);
     notifyLocationAvailabilityChanged();
     LocationManager manager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
     manager.requestSingleUpdate(provider, new android.location.LocationListener() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
@@ -192,22 +192,6 @@ public class LostClientManager implements ClientManager {
     reportedChanges.putAll(changes);
   }
 
-  @Override public void reportProviderEnabled(String provider) {
-    for (LostClientWrapper wrapper : clients.values()) {
-      for (LocationListener listener : wrapper.locationListeners()) {
-        listener.onProviderEnabled(provider);
-      }
-    }
-  }
-
-  @Override public void reportProviderDisabled(String provider) {
-    for (LostClientWrapper wrapper : clients.values()) {
-      for (LocationListener listener : wrapper.locationListeners()) {
-        listener.onProviderDisabled(provider);
-      }
-    }
-  }
-
   @Override public void notifyLocationAvailability(final LocationAvailability availability) {
     for (LostClientWrapper wrapper : clients.values()) {
       for (LocationCallback callback : wrapper.locationCallbacks()) {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceImplTest.java
@@ -384,42 +384,6 @@ public class FusedLocationProviderServiceImplTest extends BaseRobolectricTest {
     assertThat(api.isProviderEnabled(client, LocationManager.NETWORK_PROVIDER)).isFalse();
   }
 
-  @Test public void onProviderDisabled_shouldReportWhenGpsIsDisabled() throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    api.requestLocationUpdates(client, request, listener);
-    listener.setIsGpsEnabled(true);
-    shadowLocationManager.setProviderEnabled(GPS_PROVIDER, false);
-    assertThat(listener.getIsGpsEnabled()).isFalse();
-  }
-
-  @Test public void onProviderDisabled_shouldReportWhenNetworkIsDisabled() throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create();
-    api.requestLocationUpdates(client, request, listener);
-    listener.setIsNetworkEnabled(true);
-    shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, false);
-    assertThat(listener.getIsNetworkEnabled()).isFalse();
-  }
-
-  @Test public void onProviderEnabled_shouldReportWhenGpsIsEnabled() throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    api.requestLocationUpdates(client, request, listener);
-    listener.setIsGpsEnabled(false);
-    shadowLocationManager.setProviderEnabled(GPS_PROVIDER, true);
-    assertThat(listener.getIsGpsEnabled()).isTrue();
-  }
-
-  @Test public void onProviderEnabled_shouldReportWhenNetworkIsEnabled() throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create();
-    api.requestLocationUpdates(client, request, listener);
-    listener.setIsNetworkEnabled(false);
-    shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
-    assertThat(listener.getIsNetworkEnabled()).isTrue();
-  }
-
   private static Location getTestLocation(String provider, float lat, float lng, long time) {
     Location location = new Location(provider);
     location.setLatitude(lat);

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -152,12 +152,6 @@ public class LostApiClientImplTest extends BaseRobolectricTest {
         new LocationListener() {
           @Override public void onLocationChanged(Location location) {
           }
-
-          @Override public void onProviderDisabled(String provider) {
-          }
-
-          @Override public void onProviderEnabled(String provider) {
-          }
         });
 
     client.disconnect();

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostClientManagerTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostClientManagerTest.java
@@ -22,7 +22,6 @@ import android.os.Looper;
 
 import java.util.ArrayList;
 
-import static android.location.LocationManager.GPS_PROVIDER;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.robolectric.RuntimeEnvironment.application;
@@ -170,24 +169,6 @@ public class LostClientManagerTest extends BaseRobolectricTest {
     LocationResult result = LocationResult.create(locations);
     manager.reportLocationResult(location, result);
     assertThat(callback.getResult()).isEqualTo(result);
-  }
-
-  @Test public void reportProviderEnabled_shouldNotifyListeners() {
-    manager.addClient(client);
-    LocationRequest request = LocationRequest.create();
-    TestLocationListener listener = new TestLocationListener();
-    manager.addListener(client, request, listener);
-    manager.reportProviderEnabled(GPS_PROVIDER);
-    assertThat(listener.getIsGpsEnabled()).isTrue();
-  }
-
-  @Test public void reportProviderDisabled_shouldNotifyListeners() {
-    manager.addClient(client);
-    LocationRequest request = LocationRequest.create();
-    TestLocationListener listener = new TestLocationListener();
-    manager.addListener(client, request, listener);
-    manager.reportProviderDisabled(GPS_PROVIDER);
-    assertThat(listener.getIsGpsEnabled()).isFalse();
   }
 
   @Test public void notifyLocationAvailability_shouldNotifyCallback() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestLocationListener.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestLocationListener.java
@@ -7,9 +7,6 @@ import android.location.Location;
 import java.util.ArrayList;
 import java.util.List;
 
-import static android.location.LocationManager.GPS_PROVIDER;
-import static android.location.LocationManager.NETWORK_PROVIDER;
-
 public class TestLocationListener implements LocationListener {
   private ArrayList<Location> locations = new ArrayList<>();
   private boolean isGpsEnabled = true;
@@ -17,32 +14,6 @@ public class TestLocationListener implements LocationListener {
 
   @Override public void onLocationChanged(Location location) {
     locations.add(location);
-  }
-
-  @Override public void onProviderDisabled(String provider) {
-    switch (provider) {
-      case GPS_PROVIDER:
-        isGpsEnabled = false;
-        break;
-      case NETWORK_PROVIDER:
-        isNetworkEnabled = false;
-        break;
-      default:
-        break;
-    }
-  }
-
-  @Override public void onProviderEnabled(String provider) {
-    switch (provider) {
-      case GPS_PROVIDER:
-        isGpsEnabled = true;
-        break;
-      case NETWORK_PROVIDER:
-        isNetworkEnabled = true;
-        break;
-      default:
-        break;
-    }
   }
 
   public List<Location> getAllLocations() {


### PR DESCRIPTION
### Overview

Removes deprecated location listener callbacks for provider enabled/disabled.

### Proposed Changes

* Removes deprecated callbacks `LocationListener#onProviderEnabled(String)` and LocationListener#onProviderDisabled(String). Use `LocationAvailability` instead.
* Speeds up location updates in multiple location client demo for faster testing.

This is the first chunk of cleanup work for changes needed to fix #173.