### PR TITLE
Migrate PendingResult return values from FusedLocationProviderService to FusedLocationProviderApiImpl

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -107,7 +107,8 @@ public class FusedLocationProviderApiImpl
       LocationRequest request, LocationListener listener) {
     throwIfNotConnected(client);
     LostClientManager.shared().addListener(client, request, listener);
-    return service.requestLocationUpdates(request);
+    service.requestLocationUpdates(request);
+    return new SimplePendingResult(true);
   }
 
   @Override public PendingResult<Status> requestLocationUpdates(LostApiClient client,
@@ -119,14 +120,16 @@ public class FusedLocationProviderApiImpl
       LocationRequest request, LocationCallback callback, Looper looper) {
     throwIfNotConnected(client);
     LostClientManager.shared().addLocationCallback(client, request, callback, looper);
-    return service.requestLocationUpdates(request);
+    service.requestLocationUpdates(request);
+    return new SimplePendingResult(true);
   }
 
   @Override public PendingResult<Status> requestLocationUpdates(LostApiClient client,
       LocationRequest request, PendingIntent callbackIntent) {
     throwIfNotConnected(client);
     LostClientManager.shared().addPendingIntent(client, request, callbackIntent);
-    return service.requestLocationUpdates(request);
+    service.requestLocationUpdates(request);
+    return new SimplePendingResult(true);
   }
 
   @Override public PendingResult<Status> removeLocationUpdates(LostApiClient client,
@@ -155,18 +158,21 @@ public class FusedLocationProviderApiImpl
 
   @Override public PendingResult<Status> setMockMode(LostApiClient client, boolean isMockMode) {
     throwIfNotConnected(client);
-    return service.setMockMode(isMockMode);
+    service.setMockMode(isMockMode);
+    return new SimplePendingResult(true);
   }
 
   @Override public PendingResult<Status> setMockLocation(LostApiClient client,
       Location mockLocation) {
     throwIfNotConnected(client);
-    return service.setMockLocation(mockLocation);
+    service.setMockLocation(mockLocation);
+    return new SimplePendingResult(true);
   }
 
   @Override public PendingResult<Status> setMockTrace(LostApiClient client, File file) {
     throwIfNotConnected(client);
-    return service.setMockTrace(file);
+    service.setMockTrace(file);
+    return new SimplePendingResult(true);
   }
 
   public Map<LostApiClient, Set<LocationListener>> getLocationListeners() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
@@ -2,8 +2,6 @@ package com.mapzen.android.lost.internal;
 
 import com.mapzen.android.lost.api.LocationAvailability;
 import com.mapzen.android.lost.api.LocationRequest;
-import com.mapzen.android.lost.api.PendingResult;
-import com.mapzen.android.lost.api.Status;
 
 import android.app.Service;
 import android.content.Intent;
@@ -52,23 +50,23 @@ public class FusedLocationProviderService extends Service {
     return serviceImpl.getLocationAvailability();
   }
 
-  public PendingResult<Status> requestLocationUpdates(LocationRequest request) {
-    return serviceImpl.requestLocationUpdates(request);
+  public void requestLocationUpdates(LocationRequest request) {
+    serviceImpl.requestLocationUpdates(request);
   }
 
   public void removeLocationUpdates() {
     serviceImpl.removeLocationUpdates();
   }
 
-  public PendingResult<Status> setMockMode(boolean isMockMode) {
-    return serviceImpl.setMockMode(isMockMode);
+  public void setMockMode(boolean isMockMode) {
+    serviceImpl.setMockMode(isMockMode);
   }
 
-  public PendingResult<Status> setMockLocation(Location mockLocation) {
-    return serviceImpl.setMockLocation(mockLocation);
+  public void setMockLocation(Location mockLocation) {
+    serviceImpl.setMockLocation(mockLocation);
   }
 
-  public PendingResult<Status> setMockTrace(File file) {
-    return serviceImpl.setMockTrace(file);
+  public void setMockTrace(File file) {
+    serviceImpl.setMockTrace(file);
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
@@ -3,8 +3,6 @@ package com.mapzen.android.lost.internal;
 import com.mapzen.android.lost.api.LocationAvailability;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LocationResult;
-import com.mapzen.android.lost.api.PendingResult;
-import com.mapzen.android.lost.api.Status;
 
 import android.content.Context;
 import android.location.Location;
@@ -43,34 +41,30 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
     return locationEngine.createLocationAvailability();
   }
 
-  public PendingResult<Status> requestLocationUpdates(LocationRequest request) {
+  public void requestLocationUpdates(LocationRequest request) {
     locationEngine.setRequest(request);
-    return new SimplePendingResult(true);
   }
 
   public void removeLocationUpdates() {
     checkAllListenersPendingIntentsAndCallbacks();
   }
 
-  public PendingResult<Status> setMockMode(boolean isMockMode) {
+  public void setMockMode(boolean isMockMode) {
     if (mockMode != isMockMode) {
       toggleMockMode();
     }
-    return new SimplePendingResult(true);
   }
 
-  public PendingResult<Status> setMockLocation(Location mockLocation) {
+  public void setMockLocation(Location mockLocation) {
     if (mockMode) {
       ((MockEngine) locationEngine).setLocation(mockLocation);
     }
-    return new SimplePendingResult(true);
   }
 
-  public PendingResult<Status> setMockTrace(File file) {
+  public void setMockTrace(File file) {
     if (mockMode) {
       ((MockEngine) locationEngine).setTrace(file);
     }
-    return new SimplePendingResult(true);
   }
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -27,6 +27,7 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -446,6 +447,105 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
 
     assertThat(api.getLocationListeners().get(connectedClient)).isEmpty();
     assertThat(api.getLocationListeners().get(otherClient).size()).isEqualTo(1);
+  }
+
+  @Test public void requestLocationUpdates_listener_shouldReturnFusedLocationPendingResult() {
+    PendingResult<Status> result = api.requestLocationUpdates(connectedClient,
+        LocationRequest.create(), new TestLocationListener());
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    com.mapzen.android.lost.internal.TestResultCallback
+        callback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    com.mapzen.android.lost.internal.TestResultCallback
+        otherCallback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void requestLocationUpdates_pendingIntent_shouldReturnFusedLocationPendingResult() {
+    PendingResult<Status> result = api.requestLocationUpdates(connectedClient,
+        LocationRequest.create(), mock(PendingIntent.class));
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    com.mapzen.android.lost.internal.TestResultCallback
+        callback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    com.mapzen.android.lost.internal.TestResultCallback
+        otherCallback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void requestLocationUpdates_callback_shouldReturnFusedLocationPendingResult() {
+    PendingResult<Status> result = api.requestLocationUpdates(connectedClient,
+        LocationRequest.create(), new TestLocationCallback(), Looper.myLooper());
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    com.mapzen.android.lost.internal.TestResultCallback
+        callback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    com.mapzen.android.lost.internal.TestResultCallback
+        otherCallback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void setMockMode_shouldReturnFusedLocationPendingResult() {
+    PendingResult<Status> result = api.setMockMode(connectedClient, true);
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    com.mapzen.android.lost.internal.TestResultCallback
+        callback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    com.mapzen.android.lost.internal.TestResultCallback
+        otherCallback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void setMockLocation_shouldReturnFusedLocationPendingResult() {
+    PendingResult<Status> result = api.setMockLocation(connectedClient, new Location("test"));
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    com.mapzen.android.lost.internal.TestResultCallback
+        callback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    com.mapzen.android.lost.internal.TestResultCallback
+        otherCallback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+  }
+
+  @Test public void setMockTrace_shouldReturnFusedLocationPendingResult() {
+    PendingResult<Status> result = api.setMockTrace(connectedClient, new File("test"));
+    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
+        Status.SUCCESS);
+    assertThat(result.isCanceled()).isFalse();
+    com.mapzen.android.lost.internal.TestResultCallback
+        callback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(callback);
+    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
+    com.mapzen.android.lost.internal.TestResultCallback
+        otherCallback = new com.mapzen.android.lost.internal.TestResultCallback();
+    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
+    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
   }
 
   private class TestResultCallback implements ResultCallback<Status> {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
@@ -2,12 +2,9 @@ package com.mapzen.android.lost.internal;
 
 import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.android.lost.api.LocationAvailability;
-import com.mapzen.android.lost.api.LocationCallback;
 import com.mapzen.android.lost.api.LocationRequest;
 import com.mapzen.android.lost.api.LocationResult;
 import com.mapzen.android.lost.api.LostApiClient;
-import com.mapzen.android.lost.api.PendingResult;
-import com.mapzen.android.lost.api.Status;
 import com.mapzen.android.lost.shadows.LostShadowLocationManager;
 import com.mapzen.lost.BuildConfig;
 
@@ -38,7 +35,6 @@ import android.os.Looper;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 import static android.content.Context.LOCATION_SERVICE;
 import static android.location.LocationManager.GPS_PROVIDER;
@@ -1071,91 +1067,6 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     api.reportLocation(location);
     assertThat(callback.getResult()).isNotNull();
     assertThat(otherCallback.getResult()).isNotNull();
-  }
-
-  @Test public void requestLocationUpdates_listener_shouldReturnFusedLocationPendingResult() {
-    PendingResult<Status> result = api.requestLocationUpdates(LocationRequest.create());
-    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
-        Status.SUCCESS);
-    assertThat(result.isCanceled()).isFalse();
-    TestResultCallback callback = new TestResultCallback();
-    result.setResultCallback(callback);
-    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    TestResultCallback otherCallback = new TestResultCallback();
-    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
-    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-  }
-
-  @Test public void requestLocationUpdates_pendingIntent_shouldReturnFusedLocationPendingResult() {
-    PendingResult<Status> result = api.requestLocationUpdates(LocationRequest.create());
-    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
-        Status.SUCCESS);
-    assertThat(result.isCanceled()).isFalse();
-    TestResultCallback callback = new TestResultCallback();
-    result.setResultCallback(callback);
-    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    TestResultCallback otherCallback = new TestResultCallback();
-    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
-    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-  }
-
-  @Test public void requestLocationUpdates_callback_shouldReturnFusedLocationPendingResult() {
-    LocationCallback locationCallback = new TestLocationCallback();
-    PendingResult<Status> result = api.requestLocationUpdates(LocationRequest.create());
-    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
-        Status.SUCCESS);
-    assertThat(result.isCanceled()).isFalse();
-    TestResultCallback callback = new TestResultCallback();
-    result.setResultCallback(callback);
-    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    TestResultCallback otherCallback = new TestResultCallback();
-    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
-    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-  }
-
-  @Test public void setMockMode_shouldReturnFusedLocationPendingResult() {
-    PendingResult<Status> result = api.setMockMode(true);
-    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
-        Status.SUCCESS);
-    assertThat(result.isCanceled()).isFalse();
-    TestResultCallback callback = new TestResultCallback();
-    result.setResultCallback(callback);
-    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    TestResultCallback otherCallback = new TestResultCallback();
-    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
-    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-  }
-
-  @Test public void setMockLocation_shouldReturnFusedLocationPendingResult() {
-    PendingResult<Status> result = api.setMockLocation(new Location("test"));
-    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
-        Status.SUCCESS);
-    assertThat(result.isCanceled()).isFalse();
-    TestResultCallback callback = new TestResultCallback();
-    result.setResultCallback(callback);
-    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    TestResultCallback otherCallback = new TestResultCallback();
-    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
-    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-  }
-
-  @Test public void setMockTrace_shouldReturnFusedLocationPendingResult() {
-    PendingResult<Status> result = api.setMockTrace(new File("test"));
-    assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
-        Status.SUCCESS);
-    assertThat(result.isCanceled()).isFalse();
-    TestResultCallback callback = new TestResultCallback();
-    result.setResultCallback(callback);
-    assertThat(callback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
-    TestResultCallback otherCallback = new TestResultCallback();
-    result.setResultCallback(otherCallback, 1000, TimeUnit.MILLISECONDS);
-    assertThat(otherCallback.getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
   }
 
   public class TestService extends IntentService {


### PR DESCRIPTION
### Overview

Makes all methods in `FusedLocationProviderService` except `getLastLocation()` and `getLocationAvailability()` return `void`.

### Proposed Changes

`FusedLocationProviderApi` methods that return a `PendingResult` now generate the return value in the client-side API implementation rather than in the service.