### PR TITLE
Multiple process support

### DIFF
--- a/lost-sample/src/main/AndroidManifest.xml
+++ b/lost-sample/src/main/AndroidManifest.xml
@@ -32,8 +32,7 @@
 
     <activity android:name=".GeofencingApiActivity"/>
     <activity android:name=".SettingsApiActivity"/>
-    <activity android:name=".LocationListenerActivity"
-        android:process=":foo"/>
+    <activity android:name=".LocationListenerActivity"/>
     <activity android:name=".PendingIntentActivity"/>
     <activity android:name=".LocationAvailabilityActivity"/>
     <activity android:name=".MultipleLocationListenerMultipleClientsActivity"/>

--- a/lost-sample/src/main/AndroidManifest.xml
+++ b/lost-sample/src/main/AndroidManifest.xml
@@ -32,7 +32,8 @@
 
     <activity android:name=".GeofencingApiActivity"/>
     <activity android:name=".SettingsApiActivity"/>
-    <activity android:name=".LocationListenerActivity"/>
+    <activity android:name=".LocationListenerActivity"
+        android:process=":foo"/>
     <activity android:name=".PendingIntentActivity"/>
     <activity android:name=".LocationAvailabilityActivity"/>
     <activity android:name=".MultipleLocationListenerMultipleClientsActivity"/>
@@ -47,6 +48,7 @@
         <action android:name="com.mapzen.lost.intent.action.PENDING_INTENT_SERVICE"/>
       </intent-filter>
     </service>
+
 
   </application>
 </manifest>

--- a/lost-sample/src/main/java/com/example/lost/LocationListenerActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/LocationListenerActivity.java
@@ -142,8 +142,7 @@ public class LocationListenerActivity extends AppCompatActivity  implements
 
     if (prefs.getBoolean(getString(R.string.mock_mode_gpx_key), false)) {
       String filename = prefs.getString(getString(R.string.mock_gpx_file_key), null);
-      File file = new File(getExternalFilesDir(null), filename);
-      FusedLocationApi.setMockTrace(client, file);
+      FusedLocationApi.setMockTrace(client, getExternalFilesDir(null).getPath(), filename);
     }
 
     final Resources res = getResources();
@@ -357,4 +356,3 @@ public class LocationListenerActivity extends AppCompatActivity  implements
     }
   }
 }
-

--- a/lost-sample/src/main/java/com/example/lost/PendingIntentActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/PendingIntentActivity.java
@@ -54,7 +54,7 @@ public class PendingIntentActivity extends LostApiClientActivity {
 
   private void requestLocationUpdates() {
     LocationRequest request = LocationRequest.create();
-    request.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+    request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
     request.setInterval(100);
 
     Intent intent = new Intent(PendingIntentService.ACTION);

--- a/lost/src/main/AndroidManifest.xml
+++ b/lost/src/main/AndroidManifest.xml
@@ -16,7 +16,9 @@
 
   <application>
 
-    <service android:name="com.mapzen.android.lost.internal.FusedLocationProviderService"/>
+    <service
+        android:name="com.mapzen.android.lost.internal.FusedLocationProviderService"
+        android:process=":lost"/>
     <service android:name="com.mapzen.android.lost.internal.GeofencingIntentService">
       <intent-filter>
         <action android:name="com.mapzen.lost.action.ACTION_GEOFENCING_SERVICE"/>

--- a/lost/src/main/aidl/com/mapzen/android/lost/api/LocationAvailability.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/api/LocationAvailability.aidl
@@ -1,0 +1,3 @@
+package com.mapzen.android.lost.api;
+
+parcelable LocationAvailability;

--- a/lost/src/main/aidl/com/mapzen/android/lost/api/LocationRequest.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/api/LocationRequest.aidl
@@ -1,0 +1,3 @@
+package com.mapzen.android.lost.api;
+
+parcelable LocationRequest;

--- a/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderCallback.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderCallback.aidl
@@ -1,5 +1,10 @@
 package com.mapzen.android.lost.internal;
 
+import com.mapzen.android.lost.api.LocationAvailability;
+
 interface IFusedLocationProviderCallback {
+
   void onLocationChanged(in Location location);
+
+  void onLocationAvailabilityChanged(in LocationAvailability locationAvailability);
 }

--- a/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderCallback.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderCallback.aidl
@@ -1,0 +1,5 @@
+package com.mapzen.android.lost.internal;
+
+interface IFusedLocationProviderCallback {
+  void onLocationChanged(in Location location);
+}

--- a/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderService.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderService.aidl
@@ -2,8 +2,11 @@ package com.mapzen.android.lost.internal;
 
 import com.mapzen.android.lost.api.LocationAvailability;
 import com.mapzen.android.lost.api.LocationRequest;
+import com.mapzen.android.lost.internal.IFusedLocationProviderCallback;
 
 interface IFusedLocationProviderService {
+
+  void init(in IFusedLocationProviderCallback callback);
 
   Location getLastLocation();
 

--- a/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderService.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderService.aidl
@@ -1,0 +1,21 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationRequest;
+
+interface IFusedLocationProviderService {
+
+  Location getLastLocation();
+
+  LocationAvailability getLocationAvailability();
+
+  void requestLocationUpdates(in LocationRequest request);
+
+  void removeLocationUpdates();
+
+  void setMockMode(boolean isMockMode);
+
+  void setMockLocation(in Location mockLocation);
+
+  void setMockTrace(String path, String filename);
+}

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -5,8 +5,6 @@ import android.location.Location;
 import android.os.Looper;
 import android.support.annotation.RequiresPermission;
 
-import java.io.File;
-
 import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
@@ -169,7 +167,7 @@ public interface FusedLocationProviderApi {
    * This effects all {@link LostApiClient}s connected to the {@link FusedLocationProviderApi}.
    * Mock mode must be enabled before clients are able to call
    * {@link FusedLocationProviderApi#setMockLocation(LostApiClient, Location)} and
-   * {@link FusedLocationProviderApi#setMockTrace(LostApiClient, File)}
+   * {@link FusedLocationProviderApi#setMockTrace(LostApiClient, String, String)}
    *
    * @param client Connected client.
    * @param isMockMode Whether mock mode should be enabled or not.
@@ -196,9 +194,11 @@ public interface FusedLocationProviderApi {
    * Mock mode must be enabled before calling this method.
    *
    * @param client Connected client.
-   * @param file GPX file to be used to report location.
+   * @param path storage directory containing GPX trace to be used to report location.
+   * @param filename filename of GPX trace to be used to report location.
    * @return a {@link PendingResult} for the call to check whether call was successful.
    * @throws IllegalStateException if the client is not connected at the time of this call.
    */
-  PendingResult<Status> setMockTrace(LostApiClient client, final File file);
+  PendingResult<Status> setMockTrace(LostApiClient client, final String path,
+      final String filename);
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -45,6 +45,11 @@ public class FusedLocationProviderApiImpl
         }
       });
     }
+
+    @Override public void onLocationAvailabilityChanged(LocationAvailability locationAvailability)
+        throws RemoteException {
+      LostClientManager.shared().notifyLocationAvailability(locationAvailability);
+    }
   };
 
   @Override public void onConnect(Context context) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -18,8 +18,8 @@ import android.content.ServiceConnection;
 import android.location.Location;
 import android.os.IBinder;
 import android.os.Looper;
+import android.os.RemoteException;
 
-import java.io.File;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,9 +30,10 @@ public class FusedLocationProviderApiImpl
     implements FusedLocationProviderApi, EventCallbacks, ServiceConnection {
 
   private Context context;
-  private FusedLocationProviderService service;
   private FusedLocationServiceConnectionManager serviceConnectionManager;
   private boolean isBound;
+
+  IFusedLocationProviderService service;
 
   @Override public void onConnect(Context context) {
     this.context = context;
@@ -41,12 +42,8 @@ public class FusedLocationProviderApiImpl
   }
 
   @Override public void onServiceConnected(IBinder binder) {
-    FusedLocationProviderService.FusedLocationProviderBinder fusedBinder =
-        (FusedLocationProviderService.FusedLocationProviderBinder) binder;
-    if (fusedBinder != null) {
-      service = fusedBinder.getService();
+      service = IFusedLocationProviderService.Stub.asInterface(binder);
       isBound = true;
-    }
   }
 
   @Override public void onDisconnect() {
@@ -95,19 +92,31 @@ public class FusedLocationProviderApiImpl
 
   @Override public Location getLastLocation(LostApiClient client) {
     throwIfNotConnected(client);
-    return service.getLastLocation();
+    try {
+      return service.getLastLocation();
+    } catch (RemoteException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override public LocationAvailability getLocationAvailability(LostApiClient client) {
     throwIfNotConnected(client);
-    return service.getLocationAvailability();
+    try {
+      return service.getLocationAvailability();
+    } catch (RemoteException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override public PendingResult<Status> requestLocationUpdates(LostApiClient client,
       LocationRequest request, LocationListener listener) {
     throwIfNotConnected(client);
     LostClientManager.shared().addListener(client, request, listener);
-    service.requestLocationUpdates(request);
+    try {
+      service.requestLocationUpdates(request);
+    } catch (RemoteException e) {
+      throw new RuntimeException(e);
+    }
     return new SimplePendingResult(true);
   }
 
@@ -120,7 +129,11 @@ public class FusedLocationProviderApiImpl
       LocationRequest request, LocationCallback callback, Looper looper) {
     throwIfNotConnected(client);
     LostClientManager.shared().addLocationCallback(client, request, callback, looper);
-    service.requestLocationUpdates(request);
+    try {
+      service.requestLocationUpdates(request);
+    } catch (RemoteException e) {
+      throw new RuntimeException(e);
+    }
     return new SimplePendingResult(true);
   }
 
@@ -128,7 +141,11 @@ public class FusedLocationProviderApiImpl
       LocationRequest request, PendingIntent callbackIntent) {
     throwIfNotConnected(client);
     LostClientManager.shared().addPendingIntent(client, request, callbackIntent);
-    service.requestLocationUpdates(request);
+    try {
+      service.requestLocationUpdates(request);
+    } catch (RemoteException e) {
+      throw new RuntimeException(e);
+    }
     return new SimplePendingResult(true);
   }
 
@@ -136,7 +153,11 @@ public class FusedLocationProviderApiImpl
       LocationListener listener) {
     throwIfNotConnected(client);
     boolean hasResult = LostClientManager.shared().removeListener(client, listener);
-    service.removeLocationUpdates();
+    try {
+      service.removeLocationUpdates();
+    } catch (RemoteException e) {
+      throw new RuntimeException(e);
+    }
     return new SimplePendingResult(hasResult);
   }
 
@@ -144,7 +165,11 @@ public class FusedLocationProviderApiImpl
       PendingIntent callbackIntent) {
     throwIfNotConnected(client);
     boolean hasResult = LostClientManager.shared().removePendingIntent(client, callbackIntent);
-    service.removeLocationUpdates();
+    try {
+      service.removeLocationUpdates();
+    } catch (RemoteException e) {
+      throw new RuntimeException(e);
+    }
     return new SimplePendingResult(hasResult);
   }
 
@@ -152,35 +177,48 @@ public class FusedLocationProviderApiImpl
       LocationCallback callback) {
     throwIfNotConnected(client);
     boolean hasResult = LostClientManager.shared().removeLocationCallback(client, callback);
-    service.removeLocationUpdates();
+    try {
+      service.removeLocationUpdates();
+    } catch (RemoteException e) {
+      throw new RuntimeException(e);
+    }
     return new SimplePendingResult(hasResult);
   }
 
   @Override public PendingResult<Status> setMockMode(LostApiClient client, boolean isMockMode) {
     throwIfNotConnected(client);
-    service.setMockMode(isMockMode);
+    try {
+      service.setMockMode(isMockMode);
+    } catch (RemoteException e) {
+      throw new RuntimeException(e);
+    }
     return new SimplePendingResult(true);
   }
 
   @Override public PendingResult<Status> setMockLocation(LostApiClient client,
       Location mockLocation) {
     throwIfNotConnected(client);
-    service.setMockLocation(mockLocation);
+    try {
+      service.setMockLocation(mockLocation);
+    } catch (RemoteException e) {
+      throw new RuntimeException(e);
+    }
     return new SimplePendingResult(true);
   }
 
-  @Override public PendingResult<Status> setMockTrace(LostApiClient client, File file) {
+  @Override public PendingResult<Status> setMockTrace(LostApiClient client, String path,
+      String filename) {
     throwIfNotConnected(client);
-    service.setMockTrace(file);
+    try {
+      service.setMockTrace(path, filename);
+    } catch (RemoteException e) {
+      throw new RuntimeException(e);
+    }
     return new SimplePendingResult(true);
   }
 
   public Map<LostApiClient, Set<LocationListener>> getLocationListeners() {
     return LostClientManager.shared().getLocationListeners();
-  }
-
-  public FusedLocationProviderService getService() {
-    return service;
   }
 
   void removeConnectionCallbacks(LostApiClient.ConnectionCallbacks callbacks) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
@@ -6,31 +6,48 @@ import com.mapzen.android.lost.api.LocationRequest;
 import android.app.Service;
 import android.content.Intent;
 import android.location.Location;
-import android.os.Binder;
 import android.os.IBinder;
+import android.os.RemoteException;
 import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
-
-import java.io.File;
-
-import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
-import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
 /**
  * Service which runs the fused location provider in the background.
  */
 public class FusedLocationProviderService extends Service {
 
-  private FusedLocationProviderServiceDelegate serviceImpl;
+  private FusedLocationProviderServiceDelegate delegate;
 
-  private final IBinder binder = new FusedLocationProviderBinder();
+  private final IFusedLocationProviderService.Stub binder =
+      new IFusedLocationProviderService.Stub() {
+        @Override public Location getLastLocation() throws RemoteException {
+          return delegate.getLastLocation();
+        }
 
-  public class FusedLocationProviderBinder extends Binder {
+        @Override public LocationAvailability getLocationAvailability() throws RemoteException {
+          return delegate.getLocationAvailability();
+        }
 
-    public FusedLocationProviderService getService() {
-      return FusedLocationProviderService.this;
-    }
-  }
+        @Override public void requestLocationUpdates(LocationRequest request)
+            throws RemoteException {
+          delegate.requestLocationUpdates(request);
+        }
+
+        @Override public void removeLocationUpdates() throws RemoteException {
+          delegate.removeLocationUpdates();
+        }
+
+        @Override public void setMockMode(boolean isMockMode) throws RemoteException {
+          delegate.setMockMode(isMockMode);
+        }
+
+        @Override public void setMockLocation(Location mockLocation) throws RemoteException {
+          delegate.setMockLocation(mockLocation);
+        }
+
+        @Override public void setMockTrace(String path, String filename) throws RemoteException {
+          delegate.setMockTrace(path, filename);
+        }
+      };
 
   @Nullable @Override public IBinder onBind(Intent intent) {
     return binder;
@@ -38,35 +55,6 @@ public class FusedLocationProviderService extends Service {
 
   @Override public void onCreate() {
     super.onCreate();
-    serviceImpl = new FusedLocationProviderServiceDelegate(this, LostClientManager.shared());
-  }
-
-  public Location getLastLocation() {
-    return serviceImpl.getLastLocation();
-  }
-
-  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  public LocationAvailability getLocationAvailability() {
-    return serviceImpl.getLocationAvailability();
-  }
-
-  public void requestLocationUpdates(LocationRequest request) {
-    serviceImpl.requestLocationUpdates(request);
-  }
-
-  public void removeLocationUpdates() {
-    serviceImpl.removeLocationUpdates();
-  }
-
-  public void setMockMode(boolean isMockMode) {
-    serviceImpl.setMockMode(isMockMode);
-  }
-
-  public void setMockLocation(Location mockLocation) {
-    serviceImpl.setMockLocation(mockLocation);
-  }
-
-  public void setMockTrace(File file) {
-    serviceImpl.setMockTrace(file);
+    delegate = new FusedLocationProviderServiceDelegate(this, LostClientManager.shared());
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
@@ -19,6 +19,10 @@ public class FusedLocationProviderService extends Service {
 
   private final IFusedLocationProviderService.Stub binder =
       new IFusedLocationProviderService.Stub() {
+        @Override public void init(IFusedLocationProviderCallback callback) throws RemoteException {
+          delegate.init(callback);
+        }
+
         @Override public Location getLastLocation() throws RemoteException {
           return delegate.getLastLocation();
         }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
@@ -59,6 +59,6 @@ public class FusedLocationProviderService extends Service {
 
   @Override public void onCreate() {
     super.onCreate();
-    delegate = new FusedLocationProviderServiceDelegate(this, LostClientManager.shared());
+    delegate = new FusedLocationProviderServiceDelegate(this);
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
@@ -93,8 +93,7 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
     ReportedChanges pendingIntentChanges = clientManager.sendPendingIntent(
         context, location, availability, result);
 
-    ReportedChanges callbackChanges = clientManager.reportLocationResult(
-        location, result);
+    ReportedChanges callbackChanges = clientManager.reportLocationResult(location, result);
 
     changes.putAll(pendingIntentChanges);
     changes.putAll(callbackChanges);
@@ -156,6 +155,12 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   private void notifyLocationAvailabilityChanged() {
     final LocationAvailability availability = locationEngine.createLocationAvailability();
-    clientManager.notifyLocationAvailability(availability);
+    if (callback != null) {
+      try {
+        callback.onLocationAvailabilityChanged(availability);
+      } catch (RemoteException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
@@ -52,7 +52,7 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
   }
 
   public void removeLocationUpdates() {
-    checkAllListenersPendingIntentsAndCallbacks();
+    locationEngine.setRequest(null);
   }
 
   public void setMockMode(boolean isMockMode) {
@@ -130,16 +130,6 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
 
       }
     }, Looper.myLooper());
-  }
-
-  /**
-   * Checks if any listeners or pending intents are still registered for location updates. If not,
-   * then shutdown the location engines.
-   */
-  private void checkAllListenersPendingIntentsAndCallbacks() {
-    if (clientManager.hasNoListeners()) {
-      locationEngine.setRequest(null);
-    }
   }
 
   private void toggleMockMode() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
@@ -2,7 +2,6 @@ package com.mapzen.android.lost.internal;
 
 import com.mapzen.android.lost.api.LocationAvailability;
 import com.mapzen.android.lost.api.LocationRequest;
-import com.mapzen.android.lost.api.LocationResult;
 
 import android.content.Context;
 import android.location.Location;
@@ -13,7 +12,6 @@ import android.os.RemoteException;
 import android.support.annotation.RequiresPermission;
 
 import java.io.File;
-import java.util.ArrayList;
 
 import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
@@ -24,13 +22,10 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
 
   private boolean mockMode;
   private LocationEngine locationEngine;
-
-  private ClientManager clientManager;
   private IFusedLocationProviderCallback callback;
 
-  public FusedLocationProviderServiceDelegate(Context context, ClientManager manager) {
+  public FusedLocationProviderServiceDelegate(Context context) {
     this.context = context;
-    this.clientManager = manager;
     locationEngine = new FusionEngine(context, this);
   }
 
@@ -83,21 +78,6 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
         throw new RuntimeException(e);
       }
     }
-
-    ReportedChanges changes = clientManager.reportLocationChanged(location);
-
-    LocationAvailability availability = locationEngine.createLocationAvailability();
-    ArrayList<Location> locations = new ArrayList<>();
-    locations.add(location);
-    final LocationResult result = LocationResult.create(locations);
-    ReportedChanges pendingIntentChanges = clientManager.sendPendingIntent(
-        context, location, availability, result);
-
-    ReportedChanges callbackChanges = clientManager.reportLocationResult(location, result);
-
-    changes.putAll(pendingIntentChanges);
-    changes.putAll(callbackChanges);
-    clientManager.updateReportedValues(changes);
   }
 
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
@@ -61,9 +61,9 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
     }
   }
 
-  public void setMockTrace(File file) {
+  public void setMockTrace(String path, String filename) {
     if (mockMode) {
-      ((MockEngine) locationEngine).setTrace(file);
+      ((MockEngine) locationEngine).setTrace(new File(path, filename));
     }
   }
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
@@ -143,7 +143,7 @@ public class FusionEngine extends LocationEngine implements LocationListener {
 
   private void enableGps(long interval) throws SecurityException {
     try {
-      locationManager.requestLocationUpdates(GPS_PROVIDER, interval, 0, this);
+      locationManager.requestLocationUpdates(GPS_PROVIDER, interval, 0, this, getLooper());
     } catch (IllegalArgumentException e) {
       Log.e(TAG, "Unable to register for GPS updates.", e);
     }
@@ -151,7 +151,7 @@ public class FusionEngine extends LocationEngine implements LocationListener {
 
   private void enableNetwork(long interval) throws SecurityException {
     try {
-      locationManager.requestLocationUpdates(NETWORK_PROVIDER, interval, 0, this);
+      locationManager.requestLocationUpdates(NETWORK_PROVIDER, interval, 0, this, getLooper());
     } catch (IllegalArgumentException e) {
       Log.e(TAG, "Unable to register for network updates.", e);
     }
@@ -159,7 +159,7 @@ public class FusionEngine extends LocationEngine implements LocationListener {
 
   private void enablePassive(long interval) throws SecurityException {
     try {
-      locationManager.requestLocationUpdates(PASSIVE_PROVIDER, interval, 0, this);
+      locationManager.requestLocationUpdates(PASSIVE_PROVIDER, interval, 0, this, getLooper());
     } catch (IllegalArgumentException e) {
       Log.e(TAG, "Unable to register for passive updates.", e);
     }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LocationEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LocationEngine.java
@@ -6,6 +6,7 @@ import com.mapzen.android.lost.api.LocationRequest;
 import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
+import android.os.Looper;
 import android.support.annotation.RequiresPermission;
 
 import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
@@ -63,6 +64,10 @@ public abstract class LocationEngine {
 
   protected Context getContext() {
     return context;
+  }
+
+  protected Looper getLooper() {
+    return context.getMainLooper();
   }
 
   protected Callback getCallback() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
@@ -288,17 +288,17 @@ public class LostClientManager implements ClientManager {
           Long lastReportedTime = reportedChanges.timeChanges().get(request);
           Location lastReportedLocation = reportedChanges.locationChanges().get(request);
           if (lastReportedTime == null && lastReportedLocation == null) {
-            updatedRequestToReportedTime.put(request, System.currentTimeMillis());
+            updatedRequestToReportedTime.put(request, location.getTime());
             updatedRequestToReportedLocation.put(request, location);
             notifier.notify(client, obj);
           } else {
-            long intervalSinceLastReport = System.currentTimeMillis() - lastReportedTime;
+            long intervalSinceLastReport = location.getTime() - lastReportedTime;
             long fastestInterval = request.getFastestInterval();
             float smallestDisplacement = request.getSmallestDisplacement();
             float displacementSinceLastReport = location.distanceTo(lastReportedLocation);
             if (intervalSinceLastReport >= fastestInterval &&
                 displacementSinceLastReport >= smallestDisplacement) {
-              updatedRequestToReportedTime.put(request, System.currentTimeMillis());
+              updatedRequestToReportedTime.put(request, location.getTime());
               updatedRequestToReportedLocation.put(request, location);
               notifier.notify(client, obj);
             }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
@@ -3,7 +3,6 @@ package com.mapzen.android.lost.internal;
 import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.android.lost.api.LocationAvailability;
 import com.mapzen.android.lost.api.LocationRequest;
-import com.mapzen.android.lost.api.LocationResult;
 import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.android.lost.shadows.LostShadowLocationManager;
 import com.mapzen.lost.BuildConfig;
@@ -18,19 +17,16 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.internal.ShadowExtractor;
-import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowEnvironment;
 import org.robolectric.shadows.ShadowLooper;
 
 import android.app.IntentService;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Environment;
 import android.os.IBinder;
-import android.os.Looper;
 import android.os.RemoteException;
 
 import java.io.File;
@@ -40,11 +36,12 @@ import java.io.IOException;
 import static android.content.Context.LOCATION_SERVICE;
 import static android.location.LocationManager.GPS_PROVIDER;
 import static android.location.LocationManager.NETWORK_PROVIDER;
-import static com.mapzen.android.lost.api.FusedLocationProviderApi.KEY_LOCATION_CHANGED;
 import static com.mapzen.android.lost.api.LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY;
 import static com.mapzen.android.lost.api.LocationRequest.PRIORITY_HIGH_ACCURACY;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.robolectric.RuntimeEnvironment.application;
 
 @RunWith(RobolectricTestRunner.class)
@@ -57,13 +54,11 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
   private LocationManager locationManager;
   private LostShadowLocationManager shadowLocationManager;
   private LostApiClient otherClient;
-  private ClientManager clientManager;
 
   @Before public void setUp() throws Exception {
     client = new LostApiClient.Builder(mock(Context.class)).build();
     otherClient = new LostApiClient.Builder(mock(Context.class)).build();
-    clientManager = LostClientManager.shared();
-    delegate = new FusedLocationProviderServiceDelegate(application, clientManager);
+    delegate = new FusedLocationProviderServiceDelegate(application);
     locationManager = (LocationManager) application.getSystemService(LOCATION_SERVICE);
     shadowLocationManager = (LostShadowLocationManager) ShadowExtractor.extract(locationManager);
     client.connect();
@@ -90,164 +85,53 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
   }
 
   @Test public void requestLocationUpdates_shouldNotifyOnLocationChangedGps() throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.init(callback);
+    delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
+
     Location location = new Location(GPS_PROVIDER);
     shadowLocationManager.simulateLocation(location);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location);
+    assertThat(callback.location).isEqualTo(location);
   }
 
   @Test public void requestLocationUpdates_shouldNotifyOnLocationChangedNetwork() throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addListener(client, LocationRequest.create(), listener);
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.init(callback);
+    delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
+
     Location location = new Location(NETWORK_PROVIDER);
     shadowLocationManager.simulateLocation(location);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location);
+    assertThat(callback.location).isEqualTo(location);
   }
 
-  @Test public void requestLocationUpdates_shouldNotNotifyIfLessThanFastestIntervalGps()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    request.setFastestInterval(5000);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
+  @Test public void requestLocationUpdates_shouldPreferGpsIfMoreAccurate() throws Exception {
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.init(callback);
+    delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
 
-    final long time = System.currentTimeMillis();
-    Location location1 = getTestLocation(GPS_PROVIDER, 0, 0, time);
-    Location location2 = getTestLocation(GPS_PROVIDER, 1, 1, time + 1000);
-
-    shadowLocationManager.simulateLocation(location1);
-    shadowLocationManager.simulateLocation(location2);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location1);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotNotifyIfLessThanFastestIntervalNetwork()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(5000);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    final long time = System.currentTimeMillis();
-    Location location1 = getTestLocation(NETWORK_PROVIDER, 0, 0, time);
-    Location location2 = getTestLocation(NETWORK_PROVIDER, 1, 1, time + 1000);
-
-    shadowLocationManager.simulateLocation(location1);
-    shadowLocationManager.simulateLocation(location2);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location1);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotNotifyIfLessThanSmallestDisplacementGps()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    request.setSmallestDisplacement(200000);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    final long time = System.currentTimeMillis();
-    Location location1 = getTestLocation(GPS_PROVIDER, 0, 0, time);
-    Location location2 = getTestLocation(GPS_PROVIDER, 1, 1, time + 1000);
-
-    shadowLocationManager.simulateLocation(location1);
-    shadowLocationManager.simulateLocation(location2);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location1);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotNotifyIfLessThanSmallestDisplacementNetwork()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create();
-    request.setSmallestDisplacement(200000);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    final long time = System.currentTimeMillis();
-    Location location1 = getTestLocation(NETWORK_PROVIDER, 0, 0, time);
-    Location location2 = getTestLocation(NETWORK_PROVIDER, 1, 1, time + 1000);
-
-    shadowLocationManager.simulateLocation(location1);
-    shadowLocationManager.simulateLocation(location2);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location1);
-  }
-
-  @Test public void requestLocationUpdates_shouldIgnoreNetworkWhenGpsIsMoreAccurate()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    request.setFastestInterval(0);
-    request.setSmallestDisplacement(0);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    final long time = System.currentTimeMillis();
-    Location gpsLocation = getTestLocation(GPS_PROVIDER, 0, 0, time);
-    Location networkLocation = getTestLocation(NETWORK_PROVIDER, 0, 0, time + 1);
+    Location gpsLocation = getTestLocation(GPS_PROVIDER, 0, 0, 0);
+    Location networkLocation = getTestLocation(NETWORK_PROVIDER, 0, 0, 0);
 
     gpsLocation.setAccuracy(10);
     networkLocation.setAccuracy(20);
     shadowLocationManager.simulateLocation(gpsLocation);
     shadowLocationManager.simulateLocation(networkLocation);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(gpsLocation);
+    assertThat(callback.location).isEqualTo(gpsLocation);
   }
 
-  @Test public void requestLocationUpdates_shouldIgnoreGpsWhenNetworkIsMoreAccurate()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(0);
-    request.setSmallestDisplacement(0);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
+  @Test public void requestLocationUpdates_shouldPreferNetworkIfMoreAccurate() throws Exception {
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.init(callback);
+    delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
 
-    final long time = System.currentTimeMillis();
-    Location networkLocation = getTestLocation(NETWORK_PROVIDER, 0, 0, time);
-    Location gpsLocation = getTestLocation(GPS_PROVIDER, 0, 0, time + 1);
+    Location gpsLocation = getTestLocation(GPS_PROVIDER, 0, 0, 0);
+    Location networkLocation = getTestLocation(NETWORK_PROVIDER, 0, 0, 0);
 
-    networkLocation.setAccuracy(10);
     gpsLocation.setAccuracy(20);
+    networkLocation.setAccuracy(10);
     shadowLocationManager.simulateLocation(networkLocation);
     shadowLocationManager.simulateLocation(gpsLocation);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(networkLocation);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotifyWithLocationAvailabilityInPendingIntent()
-      throws Exception {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    LocationRequest locationRequest =
-        LocationRequest.create().setPriority(PRIORITY_BALANCED_POWER_ACCURACY);
-    delegate.requestLocationUpdates(locationRequest);
-    LostClientManager.shared().addPendingIntent(client, locationRequest, pendingIntent);
-    Location location = new Location(NETWORK_PROVIDER);
-    shadowLocationManager.simulateLocation(location);
-    Intent nextStartedService = ShadowApplication.getInstance().getNextStartedService();
-    assertThat(nextStartedService).isNotNull();
-    assertThat(nextStartedService.getParcelableExtra(
-        LocationAvailability.EXTRA_LOCATION_AVAILABILITY)).isNotNull();
-  }
-
-  @Test public void requestLocationUpdates_shouldNotifyWithLocationResultInPendingIntent()
-      throws Exception {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    LocationRequest locationRequest =
-        LocationRequest.create().setPriority(PRIORITY_BALANCED_POWER_ACCURACY);
-
-    LostClientManager.shared().addPendingIntent(client, locationRequest, pendingIntent);
-    delegate.requestLocationUpdates(locationRequest);
-    Location location = new Location(NETWORK_PROVIDER);
-    shadowLocationManager.simulateLocation(location);
-
-    Intent nextStartedService = ShadowApplication.getInstance().getNextStartedService();
-    assertThat(nextStartedService).isNotNull();
-    assertThat(
-        nextStartedService.getParcelableExtra(LocationResult.EXTRA_LOCATION_RESULT)).isNotNull();
+    assertThat(callback.location).isEqualTo(networkLocation);
   }
 
   @Test public void removeLocationUpdates_shouldUnregisterAllListeners() throws Exception {
@@ -272,21 +156,6 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).hasSize(2);
   }
 
-  @Test public void setMockMode_shouldToggleEngines() {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create();
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    delegate.setMockMode(true);
-    TestLocationListener listener2 = new TestLocationListener();
-    LocationRequest request2 = LocationRequest.create();
-    delegate.requestLocationUpdates(request2);
-    LostClientManager.shared().addListener(client, request2, listener2);
-
-    assertThat(clientManager.getLocationListeners().get(client)).hasSize(2);
-  }
-
   @Test public void requestLocationUpdates_shouldNotRegisterListenersWithMockModeOn()
       throws Exception {
     delegate.setMockMode(true);
@@ -302,7 +171,9 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     assertThat(delegate.getLastLocation()).isEqualTo(mockLocation);
   }
 
-  @Test public void setMockLocation_shouldInvokeListenerOnce() throws Exception {
+  @Test public void setMockLocation_shouldCallbackOnce() throws Exception {
+    IFusedLocationProviderCallback callback = mock(IFusedLocationProviderCallback.class);
+    delegate.init(callback);
     Location mockLocation = new Location("mock");
     delegate.setMockMode(true);
     TestLocationListener listener = new TestLocationListener();
@@ -310,8 +181,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     delegate.requestLocationUpdates(request);
     LostClientManager.shared().addListener(client, request, listener);
     delegate.setMockLocation(mockLocation);
-    assertThat(listener.getAllLocations()).hasSize(1);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(mockLocation);
+    verify(callback, times(1)).onLocationChanged(mockLocation);
   }
 
   public void setMockTrace_shouldInvokeListenerForEachLocation() throws Exception {
@@ -385,73 +255,10 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     fileWriter.close();
   }
 
-  @Test public void requestLocationUpdates_shouldNotifyBothListeners() {
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    TestLocationListener listener1 = new TestLocationListener();
-    TestLocationListener listener2 = new TestLocationListener();
-    delegate.requestLocationUpdates(request);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener1);
-    LostClientManager.shared().addListener(client, request, listener2);
-    Location location = new Location(GPS_PROVIDER);
-    location.setLatitude(40.0);
-    location.setLongitude(70.0);
-    shadowLocationManager.simulateLocation(location);
-    assertThat(listener1.getAllLocations()).contains(location);
-    assertThat(listener2.getAllLocations()).contains(location);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotNotifyRemovedListener() {
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    TestLocationListener listener1 = new TestLocationListener();
-    TestLocationListener listener2 = new TestLocationListener();
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener1);
-    LostClientManager.shared().addListener(client, request, listener2);
-    LostClientManager.shared().removeListener(client, listener2);
-    Location location = new Location(GPS_PROVIDER);
-    shadowLocationManager.simulateLocation(location);
-    assertThat(listener1.getAllLocations()).contains(location);
-    assertThat(listener2.getAllLocations()).doesNotContain(location);
-  }
-
   @Test public void requestLocationUpdates_shouldRegisterGpsAndNetworkListenerViaPendingIntent()
       throws Exception {
     delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).hasSize(2);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotifyOnLocationChangedGpsViaPendingIntent()
-      throws Exception {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    LocationRequest locationRequest = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-
-    LostClientManager.shared().addPendingIntent(client, locationRequest, pendingIntent);
-    delegate.requestLocationUpdates(locationRequest);
-    Location location = new Location(GPS_PROVIDER);
-    shadowLocationManager.simulateLocation(location);
-
-    Intent nextStartedService = ShadowApplication.getInstance().getNextStartedService();
-    assertThat(nextStartedService).isNotNull();
-    assertThat(nextStartedService.getParcelableExtra(KEY_LOCATION_CHANGED)).isEqualTo(location);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotifyOnLocationChangedNetworkViaPendingIntent()
-      throws Exception {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    LocationRequest locationRequest =
-        LocationRequest.create().setPriority(PRIORITY_BALANCED_POWER_ACCURACY);
-
-    LostClientManager.shared().addPendingIntent(client, locationRequest, pendingIntent);
-    delegate.requestLocationUpdates(locationRequest);
-    Location location = new Location(NETWORK_PROVIDER);
-    shadowLocationManager.simulateLocation(location);
-
-    Intent nextStartedService = ShadowApplication.getInstance().getNextStartedService();
-    assertThat(nextStartedService).isNotNull();
-    assertThat(nextStartedService.getParcelableExtra(KEY_LOCATION_CHANGED)).isEqualTo(location);
   }
 
   @Test public void removeLocationUpdates_shouldUnregisterAllPendingIntentListeners()
@@ -461,39 +268,6 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     delegate.requestLocationUpdates(locationRequest);
     delegate.removeLocationUpdates();
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isEmpty();
-  }
-
-  @Test public void requestLocationUpdates_shouldNotNotifyRemovedPendingIntent() throws Exception {
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    Intent intent1 = new Intent(application, TestService.class);
-    Intent intent2 = new Intent(application, OtherTestService.class);
-    PendingIntent pendingIntent1 = PendingIntent.getService(application, 0, intent1, 0);
-    PendingIntent pendingIntent2 = PendingIntent.getService(application, 0, intent2, 0);
-    delegate.requestLocationUpdates(request);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addPendingIntent(client, request, pendingIntent1);
-    LostClientManager.shared().addPendingIntent(client, request, pendingIntent2);
-
-    LostClientManager.shared().removePendingIntent(client, pendingIntent2);
-    Location location = new Location(GPS_PROVIDER);
-    location.setLatitude(40.0);
-    location.setLongitude(70.0);
-    shadowLocationManager.simulateLocation(location);
-
-    // Only one service should be started since the second pending intent request was removed.
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-  }
-
-  @Test public void requestLocationUpdates_shouldReportResult() {
-    TestLocationCallback callback = new TestLocationCallback();
-    Looper looper = Looper.myLooper();
-    LocationRequest request = LocationRequest.create();
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addLocationCallback(client, request, callback, looper);
-    Location location = getTestLocation(NETWORK_PROVIDER, 0, 0, 0);
-    shadowLocationManager.simulateLocation(location);
-    assertThat(callback.getResult().getLastLocation()).isEqualTo(location);
   }
 
   @Test public void requestLocationUpdates_shouldReportAvailability() {
@@ -569,458 +343,11 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isEmpty();
   }
 
-  @Test public void requestLocationUpdates_shouldModifyOnlyClientListeners() {
-    client.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addListener(client, LocationRequest.create(),
-        new TestLocationListener());
-
-    otherClient.connect();
-
-    assertThat(clientManager.getLocationListeners().get(client).size()).isEqualTo(1);
-    assertThat(clientManager.getLocationListeners().get(otherClient)).isEmpty();
-  }
-
-  @Test public void requestLocationUpdates_shouldModifyOnlyClientPendingIntents() {
-    client.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(client, LocationRequest.create(),
-        mock(PendingIntent.class));
-
-    otherClient.connect();
-
-    assertThat(clientManager.getPendingIntents().get(client).size()).isEqualTo(1);
-    assertThat(clientManager.getPendingIntents().get(otherClient)).isEmpty();
-  }
-
-  @Test public void requestLocationUpdates_shouldModifyOnlyClientLocationListeners() {
-    client.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addLocationCallback(client, LocationRequest.create(),
-        new TestLocationCallback(), Looper.myLooper());
-
-    otherClient.connect();
-
-    assertThat(clientManager.getLocationCallbacks().get(client).size()).isEqualTo(1);
-    assertThat(clientManager.getLocationCallbacks().get(otherClient)).isEmpty();
-  }
-
-  @Test public void removeLocationUpdates_shouldModifyOnlyClientPendingIntents() {
-    PendingIntent pendingIntent = mock(PendingIntent.class);
-    LocationRequest locationRequest = LocationRequest.create();
-
-    client.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(client, locationRequest, pendingIntent);
-
-    otherClient.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(otherClient, locationRequest, pendingIntent);
-
-    delegate.removeLocationUpdates();
-    LostClientManager.shared().removePendingIntent(client, pendingIntent);
-
-    assertThat(clientManager.getPendingIntents().get(client)).isEmpty();
-    assertThat(clientManager.getPendingIntents().get(otherClient).size()).isEqualTo(1);
-  }
-
-  @Test public void removeLocationUpdates_shouldModifyOnlyClientLocationListeners() {
-    TestLocationCallback callback = new TestLocationCallback();
-
-    client.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addLocationCallback(client, LocationRequest.create(), callback,
-        Looper.myLooper());
-
-    otherClient.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addLocationCallback(otherClient, LocationRequest.create(), callback,
-        Looper.myLooper());
-
-    LostClientManager.shared().removeLocationCallback(client, callback);
-    delegate.removeLocationUpdates();
-
-    assertThat(clientManager.getLocationCallbacks().get(client)).isEmpty();
-    assertThat(clientManager.getLocationCallbacks().get(otherClient).size()).isEqualTo(1);
-  }
-
-  @Test public void reportLocation_shouldNotifyClientListener() {
-    TestLocationListener listener = new TestLocationListener();
-    client.connect();
-    LostClientManager.shared().addListener(client, LocationRequest.create(), listener);
-
-    TestLocationListener otherListener = new TestLocationListener();
-    otherClient.connect();
-    LostClientManager.shared().addListener(otherClient, LocationRequest.create(), otherListener);
-    LostClientManager.shared().removeListener(otherClient, otherListener);
-
-    Location location = new Location("test");
-    delegate.reportLocation(location);
-
-    assertThat(listener.getAllLocations()).contains(location);
-    assertThat(otherListener.getAllLocations()).isEmpty();
-  }
-
-  @Test public void reportLocation_shouldNotifyPendingIntents() {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-
-    client.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(client, LocationRequest.create(), pendingIntent);
-
-    PendingIntent otherPendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    otherClient.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(otherClient, LocationRequest.create(),
-        otherPendingIntent);
-    LostClientManager.shared().removePendingIntent(otherClient, otherPendingIntent);
-    delegate.removeLocationUpdates();
-
-    Location location = new Location("test");
-    delegate.reportLocation(location);
-
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-  }
-
   @Test public void reportProviderEnabled_shouldNotifyAvailabilityChanged() throws Exception {
     TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
     delegate.init(callback);
     delegate.reportProviderEnabled(GPS_PROVIDER);
     assertThat(callback.locationAvailability).isNotNull();
-  }
-
-  @Test public void reportLocation_shouldNotifyBothListeners() {
-    TestLocationListener listener = new TestLocationListener();
-    client.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addListener(client, LocationRequest.create(), listener);
-
-    TestLocationListener otherListener = new TestLocationListener();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addListener(otherClient, otherRequest, otherListener);
-
-    Location location = new Location("test");
-    delegate.reportLocation(location);
-    assertThat(listener.getAllLocations()).contains(location);
-    assertThat(otherListener.getAllLocations()).contains(location);
-  }
-
-  @Test public void reportLocation_listener_shouldRespectFastestInterval() {
-    TestLocationListener listener = new TestLocationListener();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    TestLocationListener otherListener = new TestLocationListener();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addListener(otherClient, otherRequest, otherListener);
-
-    delegate.reportLocation(new Location("test"));
-    listener.getAllLocations().clear();
-    otherListener.getAllLocations().clear();
-
-    Location location = new Location("test");
-    delegate.reportLocation(location);
-    assertThat(listener.getAllLocations()).isEmpty();
-    assertThat(otherListener.getAllLocations().size()).isEqualTo(1);
-  }
-
-  @Test public void reportLocation_listener_shouldRespectSmallestDisplacement() {
-    TestLocationListener listener = new TestLocationListener();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setSmallestDisplacement(10);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    TestLocationListener otherListener = new TestLocationListener();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addListener(otherClient, otherRequest, otherListener);
-
-    delegate.reportLocation(new Location("test"));
-    listener.getAllLocations().clear();
-    otherListener.getAllLocations().clear();
-
-    Location location = new Location("test");
-    delegate.reportLocation(location);
-    assertThat(listener.getAllLocations()).isEmpty();
-    assertThat(otherListener.getAllLocations().size()).isEqualTo(1);
-  }
-
-  @Test public void reportLocation_listener_shouldRespectLargestIntervalAndSmallestDisplacement()
-      throws InterruptedException {
-    TestLocationListener listener = new TestLocationListener();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    request.setSmallestDisplacement(10);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    TestLocationListener otherListener = new TestLocationListener();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addListener(otherClient, otherRequest, otherListener);
-
-    delegate.reportLocation(new Location("test"));
-    listener.getAllLocations().clear();
-    otherListener.getAllLocations().clear();
-
-    Location location = new Location("test");
-    location.setLatitude(70.0);
-    location.setLongitude(40.0);
-    delegate.reportLocation(location);
-    assertThat(listener.getAllLocations()).isEmpty();
-    assertThat(otherListener.getAllLocations().size()).isEqualTo(1);
-
-    delegate.reportLocation(new Location("test"));
-    assertThat(listener.getAllLocations()).isEmpty();
-    assertThat(otherListener.getAllLocations().size()).isEqualTo(2);
-
-    Thread.sleep(1000);
-    delegate.reportLocation(location);
-    assertThat(listener.getAllLocations().size()).isEqualTo(1);
-    assertThat(otherListener.getAllLocations().size()).isEqualTo(3);
-  }
-
-  @Test public void reportLocation_shouldNotifyBothPendingIntents() {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    client.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(client, LocationRequest.create(), pendingIntent);
-
-    Intent otherIntent = new Intent(application, TestService.class);
-    PendingIntent otherPendingIntent = PendingIntent.getService(application, 0, otherIntent, 0);
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addPendingIntent(otherClient, LocationRequest.create(),
-        otherPendingIntent);
-
-    Location location = new Location("test");
-    delegate.reportLocation(location);
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-  }
-
-  @Test public void reportLocation_pendingIntent_shouldRespectFastestInterval() {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addPendingIntent(client, request, pendingIntent);
-
-    Intent otherIntent = new Intent(application, TestService.class);
-    PendingIntent otherPendingIntent = PendingIntent.getService(application, 0, otherIntent, 0);
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addPendingIntent(otherClient, otherRequest, otherPendingIntent);
-
-    delegate.reportLocation(new Location("test"));
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-
-    Location location = new Location("test");
-    delegate.reportLocation(location);
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-  }
-
-  @Test public void reportLocation_pendingIntent_shouldRespectSmallestDisplacement() {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addPendingIntent(client, request, pendingIntent);
-
-    Intent otherIntent = new Intent(application, TestService.class);
-    PendingIntent otherPendingIntent = PendingIntent.getService(application, 0, otherIntent, 0);
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addPendingIntent(otherClient, otherRequest, otherPendingIntent);
-
-    delegate.reportLocation(new Location("test"));
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-
-    Location location = new Location("test");
-    delegate.reportLocation(location);
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-  }
-
-  @Test public void reportLocation_pendingIntent_shouldRespectLargestIntervalSmallestDisplacement()
-      throws InterruptedException {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    request.setSmallestDisplacement(10);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addPendingIntent(client, request, pendingIntent);
-
-    Intent otherIntent = new Intent(application, TestService.class);
-    PendingIntent otherPendingIntent = PendingIntent.getService(application, 0, otherIntent, 0);
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addPendingIntent(otherClient, otherRequest, otherPendingIntent);
-
-    delegate.reportLocation(new Location("test"));
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-
-    Location location = new Location("test");
-    location.setLatitude(70.0);
-    location.setLongitude(40.0);
-    delegate.reportLocation(location);
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-
-    delegate.reportLocation(new Location("test"));
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-
-    Thread.sleep(1000);
-    delegate.reportLocation(location);
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-  }
-
-  @Test public void reportLocation_shouldNotifyBothCallbacks() {
-    TestLocationCallback callback = new TestLocationCallback();
-    client.connect();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addLocationCallback(client, LocationRequest.create(), callback,
-        Looper.myLooper());
-
-    TestLocationCallback otherCallback = new TestLocationCallback();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addLocationCallback(otherClient, LocationRequest.create(),
-        otherCallback, Looper.myLooper());
-
-    Location location = new Location("test");
-    delegate.reportLocation(location);
-    assertThat(callback.getResult()).isNotNull();
-    assertThat(otherCallback.getResult()).isNotNull();
-  }
-
-  @Test public void reportLocation_callback_shouldRespectFastestInterval() {
-    TestLocationCallback callback = new TestLocationCallback();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addLocationCallback(client, request, callback, Looper.myLooper());
-
-    TestLocationCallback otherCallback = new TestLocationCallback();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addLocationCallback(otherClient, otherRequest, otherCallback,
-        Looper.myLooper());
-
-    delegate.reportLocation(new Location("test"));
-    callback.setResult(null);
-    otherCallback.setResult(null);
-
-    Location location = new Location("test");
-    delegate.reportLocation(location);
-    assertThat(callback.getResult()).isNull();
-    assertThat(otherCallback.getResult()).isNotNull();
-  }
-
-  @Test public void reportLocation_callback_shouldRespectSmallestDisplacement() {
-    TestLocationCallback callback = new TestLocationCallback();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setSmallestDisplacement(10);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addLocationCallback(client, request, callback, Looper.myLooper());
-
-    TestLocationCallback otherCallback = new TestLocationCallback();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addLocationCallback(otherClient, otherRequest, otherCallback,
-        Looper.myLooper());
-
-    delegate.reportLocation(new Location("test"));
-    callback.setResult(null);
-    otherCallback.setResult(null);
-
-    Location location = new Location("test");
-    delegate.reportLocation(location);
-    assertThat(callback.getResult()).isNull();
-    assertThat(otherCallback.getResult()).isNotNull();
-  }
-
-  @Test public void reportLocation_callback_shouldRespectLargestIntervalAndSmallestDisplacement()
-      throws InterruptedException {
-    TestLocationCallback callback = new TestLocationCallback();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    request.setSmallestDisplacement(10);
-    delegate.requestLocationUpdates(request);
-    LostClientManager.shared().addLocationCallback(client, request, callback, Looper.myLooper());
-
-    TestLocationCallback otherCallback = new TestLocationCallback();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    delegate.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addLocationCallback(otherClient, otherRequest, otherCallback,
-        Looper.myLooper());
-
-    delegate.reportLocation(new Location("test"));
-    callback.setResult(null);
-    otherCallback.setResult(null);
-
-    Location location = new Location("test");
-    location.setLatitude(70.0);
-    location.setLongitude(40.0);
-    delegate.reportLocation(location);
-    assertThat(callback.getResult()).isNull();
-    assertThat(otherCallback.getResult()).isNotNull();
-
-    delegate.reportLocation(new Location("test"));
-    assertThat(callback.getResult()).isNull();
-    assertThat(otherCallback.getResult()).isNotNull();
-
-    Thread.sleep(1000);
-    delegate.reportLocation(location);
-    assertThat(callback.getResult()).isNotNull();
-    assertThat(otherCallback.getResult()).isNotNull();
   }
 
   public class TestService extends IntentService {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
@@ -562,28 +562,6 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     assertThat(availability.isLocationAvailable()).isFalse();
   }
 
-  @Test public void removeLocationUpdates_shouldNotKillEngineIfListenerStillActive()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addListener(client, LocationRequest.create(), listener);
-    delegate.requestLocationUpdates(LocationRequest.create());
-    delegate.removeLocationUpdates();
-    assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isNotEmpty();
-  }
-
-  @Test public void removeLocationUpdates_shouldNotKillEngineIfIntentStillActive()
-      throws Exception {
-    delegate.requestLocationUpdates(LocationRequest.create());
-
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, new Intent(), 0);
-    delegate.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(client, LocationRequest.create(), pendingIntent);
-
-    delegate.removeLocationUpdates();
-    assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isNotEmpty();
-  }
-
   @Test public void removeLocationUpdates_locationCallback_shouldUnregisterAllListeners() {
     LocationRequest request = LocationRequest.create();
     delegate.requestLocationUpdates(request);

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -14,14 +14,12 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import android.content.ComponentName;
 import android.location.Location;
 import android.location.LocationManager;
 
 import static android.content.Context.LOCATION_SERVICE;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.robolectric.RuntimeEnvironment.application;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -35,12 +33,6 @@ public class LostApiClientImplTest extends BaseRobolectricTest {
     LostClientManager.shared().clearClients();
     callbacks = new TestConnectionCallbacks();
     client = new LostApiClientImpl(application, callbacks, LostClientManager.shared());
-
-    FusedLocationProviderService.FusedLocationProviderBinder stubBinder =
-        mock(FusedLocationProviderService.FusedLocationProviderBinder.class);
-    when(stubBinder.getService()).thenReturn(mock(FusedLocationProviderService.class));
-    shadowOf(application).setComponentNameAndServiceForBindService(
-        new ComponentName("com.mapzen.lost", "FusedLocationProviderService"), stubBinder);
   }
 
   @After public void tearDown() throws Exception {
@@ -149,6 +141,8 @@ public class LostApiClientImplTest extends BaseRobolectricTest {
 
   @Test public void disconnect_shouldUnregisterLocationUpdateListeners() throws Exception {
     client.connect();
+    ((FusedLocationProviderApiImpl) LocationServices.FusedLocationApi).service =
+        mock(IFusedLocationProviderService.class);
     LocationServices.FusedLocationApi.requestLocationUpdates(client, LocationRequest.create(),
         new LocationListener() {
           @Override public void onLocationChanged(Location location) {


### PR DESCRIPTION
### Overview

Adds multiple process support for Lost fused location provider service.

### Proposed Changes

* Modifies `FusedLocationProviderService` to run in its own process.
* Adds AIDL interface `FusedLocationProviderService`.
* Replaces `FusedLocationProviderBinder` with `IFusedLocationProviderService.Stub`.
* Changes `setMockTrace(File)` to `setMockTrace(String, String)` so they can be passed over IPC.
* Use service's looper when registering as a location listener with `LocationManager`. This also may resolve the issue originally reported here https://github.com/mapzen/lost/issues/131.
* Delivers location updates via `IFusedLocationProviderCallback` AIDL interface and notifies `LostClientManager` on UI thread.
* Moves logic for tracking reported changes from service to `FusedLocationProviderApiImpl#onLocationChanged(Location)`.

Currently remote exceptions that can be produced when using AIDL are handled by wrapping the checked exception and throwing a new `RuntimeException`. It's possible there is a better way to handle these perhaps by invoking `LostApiClient.ConnectionCallbacks#onConnectionSuspended()`.

Fixes #173