### PR TITLE
Fix memory leak

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/api/LostApiClient.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LostApiClient.java
@@ -23,7 +23,7 @@ public interface LostApiClient {
     private ConnectionCallbacks connectionCallbacks;
 
     public Builder(Context context) {
-      this.context = context;
+      this.context = context.getApplicationContext();
     }
 
     public Builder addConnectionCallbacks(ConnectionCallbacks callbacks) {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
@@ -21,7 +21,6 @@ import org.robolectric.shadows.ShadowEnvironment;
 import org.robolectric.shadows.ShadowLooper;
 
 import android.app.IntentService;
-import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
 import android.location.LocationManager;
@@ -56,8 +55,8 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
   private LostApiClient otherClient;
 
   @Before public void setUp() throws Exception {
-    client = new LostApiClient.Builder(mock(Context.class)).build();
-    otherClient = new LostApiClient.Builder(mock(Context.class)).build();
+    client = new LostApiClient.Builder(application).build();
+    otherClient = new LostApiClient.Builder(application).build();
     delegate = new FusedLocationProviderServiceDelegate(application);
     locationManager = (LocationManager) application.getSystemService(LOCATION_SERVICE);
     shadowLocationManager = (LostShadowLocationManager) ShadowExtractor.extract(locationManager);

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostClientManagerTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostClientManagerTest.java
@@ -7,6 +7,7 @@ import com.mapzen.android.lost.api.LocationResult;
 import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.lost.BuildConfig;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -32,7 +33,11 @@ import static org.robolectric.RuntimeEnvironment.application;
 public class LostClientManagerTest extends BaseRobolectricTest {
 
   LostClientManager manager = new LostClientManager();
-  LostApiClient client = new LostApiClient.Builder(application).build();
+  LostApiClient client;
+
+  @Before public void setup() throws Exception {
+    client = new LostApiClient.Builder(application).build();
+  }
 
   @Test public void shouldHaveZeroClientCount() {
     assertThat(manager.numberOfClients()).isEqualTo(0);

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostClientWrapperTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostClientWrapperTest.java
@@ -1,13 +1,19 @@
 package com.mapzen.android.lost.internal;
 
 import com.mapzen.android.lost.api.LostApiClient;
+import com.mapzen.lost.BuildConfig;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21, manifest = Config.NONE)
 public class LostClientWrapperTest {
   private LostClientWrapper wrapper;
   private LostApiClient client;


### PR DESCRIPTION
### Overview
- Migrates `LostApiClient` to use the application context which will exist as long as the hosting process does
- Minor fixes to tests to execute after the Robolectric context is created and to run with Robolectric

Closes #175 
