### PR TITLE
update snapshot script to use printVersion task

### DIFF
--- a/scripts/deploy-snapshot.sh
+++ b/scripts/deploy-snapshot.sh
@@ -2,12 +2,10 @@
 #
 # Builds and uploads snapshot AARs to https://oss.sonatype.org/content/repositories/snapshots/com/mapzen/.
 #
-
-while read -r line || [[ -n "$line" ]]; do
-  if [[ $line =~ .*version=.*-SNAPSHOT.* ]]
-  then
-    ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME  \
-        -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
-    break
-  fi
-done < "gradle.properties"
+version=$(./gradlew -q printVersion)
+if [[ $version =~ .*-SNAPSHOT.* ]]
+then
+  ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME  \
+      -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
+  break
+fi


### PR DESCRIPTION
### Overview
Instead of looping through `gradle.properties` to find the version, use the version returned from the`printVersion` task.
