### PR TITLE
Unregister service callbacks on disconnect

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -83,19 +83,12 @@ public class FusedLocationProviderApiImpl extends ApiImpl
   @Override public void onServiceConnected(IBinder binder) {
     service = IFusedLocationProviderService.Stub.asInterface(binder);
     isBound = true;
-
-    // Register remote callback
-    if (service != null) {
-      try {
-        service.init(remoteCallback);
-      } catch (RemoteException e) {
-        throw new RuntimeException(e);
-      }
-    }
+    registerRemoteCallback();
   }
 
   @Override public void onDisconnect() {
     if (isBound) {
+      unregisterRemoteCallback();
       context.unbindService(this);
       isBound = false;
     }
@@ -277,5 +270,25 @@ public class FusedLocationProviderApiImpl extends ApiImpl
 
   FusedLocationServiceConnectionManager getServiceConnectionManager() {
     return serviceConnectionManager;
+  }
+
+  void registerRemoteCallback() {
+    if (service != null) {
+      try {
+        service.init(remoteCallback);
+      } catch (RemoteException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  void unregisterRemoteCallback() {
+    if (service != null) {
+      try {
+        service.init(null);
+      } catch (RemoteException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -260,6 +260,12 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
         Context.BIND_AUTO_CREATE);
   }
 
+  @Test public void onServiceConnected_shouldRegisterServiceCallbacks() throws Exception {
+    TestServiceStub binder = new TestServiceStub();
+    api.onServiceConnected(binder);
+    assertThat(binder.callback).isNotNull();
+  }
+
   @Test public void onDisconnect_shouldUnbindServiceIfBound() throws Exception {
     Context context = mock(Context.class);
     api.onConnect(context);
@@ -281,6 +287,13 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
     api.onDisconnect();
     api.onDisconnect();
     verify(context, times(1)).unbindService(api);
+  }
+
+  @Test public void onDisconnect_shouldUnregisterServiceCallbacks() throws Exception {
+    Context context = mock(Context.class);
+    api.onConnect(context);
+    api.onDisconnect();
+    verify(service).init(null);
   }
 
   @Test public void removeLocationUpdates_shouldReturnStatusSuccessIfListenerRemoved() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestServiceStub.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestServiceStub.java
@@ -1,0 +1,44 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationRequest;
+
+import android.location.Location;
+import android.os.RemoteException;
+
+public class TestServiceStub extends IFusedLocationProviderService.Stub {
+
+  IFusedLocationProviderCallback callback;
+
+  @Override public void init(IFusedLocationProviderCallback callback) throws RemoteException {
+    this.callback = callback;
+  }
+
+  @Override public Location getLastLocation() throws RemoteException {
+    return null;
+  }
+
+  @Override public LocationAvailability getLocationAvailability() throws RemoteException {
+    return null;
+  }
+
+  @Override public void requestLocationUpdates(LocationRequest request) throws RemoteException {
+
+  }
+
+  @Override public void removeLocationUpdates() throws RemoteException {
+
+  }
+
+  @Override public void setMockMode(boolean isMockMode) throws RemoteException {
+
+  }
+
+  @Override public void setMockLocation(Location mockLocation) throws RemoteException {
+
+  }
+
+  @Override public void setMockTrace(String path, String filename) throws RemoteException {
+
+  }
+}


### PR DESCRIPTION
### Overview
This PR fixes a race condition that existed when the `LocationEngine` received a location update after the service was disconnected

### Proposed Changes
These changes balance out the connect/disconnect flow from:
`connect -> bind -> register for service callbacks -> unbind -> consider disconnected`
to:
`connect -> bind -> register for service callbacks unregister for service callbacks -> unbind -> consider disconnected`

To reproduce this I created a `BroadcastReceiver` in `LocationEngine` and fired a dummy sample intent to this receiver in `FusedLocationProviderApiImpl#disconnect`

```
05-17 17:37:00.421 23377-23377/com.example.lost E/AndroidRuntime: FATAL EXCEPTION: main
                                                                  Process: com.example.lost, PID: 23377
                                                                  java.lang.NullPointerException: Attempt to invoke interface method 'com.mapzen.android.lost.api.LocationAvailability com.mapzen.android.lost.internal.IFusedLocationProviderService.getLocationAvailability()' on a null object reference
                                                                      at com.mapzen.android.lost.internal.FusedLocationProviderApiImpl$1$1.run(FusedLocationProviderApiImpl.java:52)
                                                                      at android.os.Handler.handleCallback(Handler.java:739)
                                                                      at android.os.Handler.dispatchMessage(Handler.java:95)
                                                                      at android.os.Looper.loop(Looper.java:158)
                                                                      at android.app.ActivityThread.main(ActivityThread.java:7229)
                                                                      at java.lang.reflect.Method.invoke(Native Method)
                                                                      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
                                                                      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)
```

Closes #198 