### PR TITLE
Unregister callbacks

### DIFF
--- a/lost-sample/src/main/java/com/example/lost/GeofencingApiActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/GeofencingApiActivity.java
@@ -21,6 +21,7 @@ import static com.mapzen.android.lost.api.Geofence.NEVER_EXPIRE;
  */
 public class GeofencingApiActivity extends LostApiClientActivity {
 
+  private Button createButton;
   private TextView inputRequestId;
   private TextView inputLatitude;
   private TextView inputLongitude;
@@ -31,37 +32,28 @@ public class GeofencingApiActivity extends LostApiClientActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_geofencing);
 
-    initConnectButton();
-    initDisconnectButton();
     initInputFields();
     initCreateButton();
+
+    connect();
+  }
+
+  @Override protected void onDestroy() {
+    disconnect();
+    createButton.setEnabled(false);
+    super.onDestroy();
   }
 
   @Override protected void disconnect() {
-    LocationServices.GeofencingApi.removeGeofences(client, pendingIntent);
+    if (pendingIntent != null) {
+      LocationServices.GeofencingApi.removeGeofences(client, pendingIntent);;
+    }
     super.disconnect();
   }
 
-  private void initConnectButton() {
-    Button connectButton = (Button) findViewById(R.id.button_connect);
-    if (connectButton != null) {
-      connectButton.setOnClickListener(new View.OnClickListener() {
-        @Override public void onClick(View v) {
-          connect();
-        }
-      });
-    }
-  }
-
-  private void initDisconnectButton() {
-    Button disconnectButton = (Button) findViewById(R.id.button_disconnect);
-    if (disconnectButton != null) {
-      disconnectButton.setOnClickListener(new View.OnClickListener() {
-        @Override public void onClick(View v) {
-          disconnect();
-        }
-      });
-    }
+  @Override public void onConnected() {
+    super.onConnected();
+    createButton.setEnabled(true);
   }
 
   private void initInputFields() {
@@ -72,7 +64,7 @@ public class GeofencingApiActivity extends LostApiClientActivity {
   }
 
   private void initCreateButton() {
-    Button createButton = (Button) findViewById(R.id.button_create);
+    createButton = (Button) findViewById(R.id.button_create);
     if (createButton != null) {
       createButton.setOnClickListener(new View.OnClickListener() {
         @Override public void onClick(View v) {

--- a/lost-sample/src/main/java/com/example/lost/GeofencingApiActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/GeofencingApiActivity.java
@@ -46,7 +46,7 @@ public class GeofencingApiActivity extends LostApiClientActivity {
 
   @Override protected void disconnect() {
     if (pendingIntent != null) {
-      LocationServices.GeofencingApi.removeGeofences(client, pendingIntent);;
+      LocationServices.GeofencingApi.removeGeofences(client, pendingIntent);
     }
     super.disconnect();
   }

--- a/lost-sample/src/main/java/com/example/lost/GeofencingApiActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/GeofencingApiActivity.java
@@ -25,6 +25,7 @@ public class GeofencingApiActivity extends LostApiClientActivity {
   private TextView inputLatitude;
   private TextView inputLongitude;
   private TextView inputRadius;
+  private PendingIntent pendingIntent;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -34,6 +35,11 @@ public class GeofencingApiActivity extends LostApiClientActivity {
     initDisconnectButton();
     initInputFields();
     initCreateButton();
+  }
+
+  @Override protected void disconnect() {
+    LocationServices.GeofencingApi.removeGeofences(client, pendingIntent);
+    super.disconnect();
   }
 
   private void initConnectButton() {
@@ -94,7 +100,7 @@ public class GeofencingApiActivity extends LostApiClientActivity {
         .addGeofence(geofence)
         .build();
     Intent serviceIntent = new Intent(getApplicationContext(), GeofenceIntentService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(this, 0, serviceIntent, 0);
+    pendingIntent = PendingIntent.getService(this, 0, serviceIntent, 0);
 
     LocationServices.GeofencingApi.addGeofences(client, request, pendingIntent);
   }

--- a/lost-sample/src/main/java/com/example/lost/LocationAvailabilityActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/LocationAvailabilityActivity.java
@@ -43,7 +43,15 @@ public class LocationAvailabilityActivity extends AppCompatActivity {
         setupLocationAvailabilityBtn();
     }
 
-    private void setupLocationAvailabilityBtn() {
+  @Override protected void onDestroy() {
+    super.onDestroy();
+    if (client != null && client.isConnected()) {
+      LocationServices.FusedLocationApi.removeLocationUpdates(client, callback);
+      client.disconnect();
+    }
+  }
+
+  private void setupLocationAvailabilityBtn() {
         Button connect = (Button) findViewById(R.id.check_availability);
         connect.setOnClickListener(new View.OnClickListener() {
             @Override public void onClick(View v) {

--- a/lost-sample/src/main/java/com/example/lost/LocationListenerActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/LocationListenerActivity.java
@@ -222,7 +222,11 @@ public class LocationListenerActivity extends AppCompatActivity  implements
 
   private void disconnect() {
     Log.d(TAG, "Disconnecting...");
-    client.disconnect();
+    if (client.isConnected()) {
+      FusedLocationApi.removeLocationUpdates(client, listener);
+      client.disconnect();
+    }
+    client.unregisterConnectionCallbacks(this);
   }
 
   private void reset() {

--- a/lost-sample/src/main/java/com/example/lost/LostApiClientActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/LostApiClientActivity.java
@@ -67,6 +67,7 @@ public class LostApiClientActivity extends AppCompatActivity implements
   protected void disconnect() {
     Log.d(TAG, "Disconnecting...");
     client.disconnect();
+    client.unregisterConnectionCallbacks(this);
     Toast.makeText(this, "LOST client disconnected", LENGTH_SHORT).show();
   }
 }

--- a/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerMultipleClientsActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerMultipleClientsActivity.java
@@ -22,7 +22,7 @@ import java.util.List;
  * Demonstrates two {@link LostApiClient}s receiving location updates at difference intervals
  */
 public class MultipleLocationListenerMultipleClientsActivity extends ListActivity
-    implements LocationListener {
+    implements LocationListener, LostApiClient.ConnectionCallbacks {
 
   private static final int LOCATION_PERMISSION_REQUEST = 1;
 
@@ -51,17 +51,17 @@ public class MultipleLocationListenerMultipleClientsActivity extends ListActivit
     }
 
     lostApiClient = new LostApiClient.Builder(this).addConnectionCallbacks(
-        new LostApiClient.ConnectionCallbacks() {
-          @Override
-          public void onConnected() {
-            initLocationTracking();
-          }
+        this).build();
+  }
 
-          @Override
-          public void onConnectionSuspended() {
+  @Override
+  public void onConnected() {
+    initLocationTracking();
+  }
 
-          }
-        }).build();
+  @Override
+  public void onConnectionSuspended() {
+
   }
 
   @Override public void onStart() {
@@ -74,6 +74,7 @@ public class MultipleLocationListenerMultipleClientsActivity extends ListActivit
     LocationServices.FusedLocationApi.removeLocationUpdates(lostApiClient,
         MultipleLocationListenerMultipleClientsActivity.this);
     lostApiClient.disconnect();
+    lostApiClient.unregisterConnectionCallbacks(this);
   }
 
   private void initLocationTracking() {
@@ -109,7 +110,8 @@ public class MultipleLocationListenerMultipleClientsActivity extends ListActivit
     adapter.notifyDataSetChanged();
   }
 
-  public static class LostClientFragment extends android.app.Fragment implements LocationListener {
+  public static class LostClientFragment extends android.app.Fragment implements LocationListener,
+      LostApiClient.ConnectionCallbacks {
 
     private static final int LOCATION_PERMISSION_REQUEST = 2;
 
@@ -117,18 +119,18 @@ public class MultipleLocationListenerMultipleClientsActivity extends ListActivit
 
     @Override public void onCreate(Bundle savedInstanceState) {
       super.onCreate(savedInstanceState);
-      fragmentClient = new LostApiClient.Builder(this.getActivity()).addConnectionCallbacks(
-          new LostApiClient.ConnectionCallbacks() {
-            @Override
-            public void onConnected() {
-              fragmentInitLocationTracking();
-            }
+      fragmentClient = new LostApiClient.Builder(this.getActivity()).addConnectionCallbacks(this).
+          build();
+    }
 
-            @Override
-            public void onConnectionSuspended() {
+    @Override
+    public void onConnected() {
+      fragmentInitLocationTracking();
+    }
 
-            }
-          }).build();
+    @Override
+    public void onConnectionSuspended() {
+
     }
 
     @Override public void onStart() {
@@ -140,6 +142,7 @@ public class MultipleLocationListenerMultipleClientsActivity extends ListActivit
       super.onStop();
       LocationServices.FusedLocationApi.removeLocationUpdates(fragmentClient, this);
       fragmentClient.disconnect();
+      fragmentClient.unregisterConnectionCallbacks(this);
     }
 
     private void fragmentInitLocationTracking() {

--- a/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerSingleClientActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/MultipleLocationListenerSingleClientActivity.java
@@ -20,7 +20,8 @@ import java.util.List;
 /**
  * Demonstrates one {@link LostApiClient}s receiving location updates at difference intervals
  */
-public class MultipleLocationListenerSingleClientActivity extends ListActivity {
+public class MultipleLocationListenerSingleClientActivity extends ListActivity implements
+    LostApiClient.ConnectionCallbacks {
 
   private static final int LOCATION_PERMISSION_REQUEST = 1;
 
@@ -50,18 +51,17 @@ public class MultipleLocationListenerSingleClientActivity extends ListActivity {
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
-    lostApiClient = new LostApiClient.Builder(this).addConnectionCallbacks(
-        new LostApiClient.ConnectionCallbacks() {
-          @Override
-          public void onConnected() {
-            initLocationTracking();
-          }
+    lostApiClient = new LostApiClient.Builder(this).addConnectionCallbacks(this).build();
+  }
 
-          @Override
-          public void onConnectionSuspended() {
+  @Override
+  public void onConnected() {
+    initLocationTracking();
+  }
 
-          }
-        }).build();
+  @Override
+  public void onConnectionSuspended() {
+
   }
 
   @Override public void onStart() {
@@ -74,6 +74,7 @@ public class MultipleLocationListenerSingleClientActivity extends ListActivity {
     LocationServices.FusedLocationApi.removeLocationUpdates(lostApiClient, listener);
     LocationServices.FusedLocationApi.removeLocationUpdates(lostApiClient, otherListener);
     lostApiClient.disconnect();
+    lostApiClient.unregisterConnectionCallbacks(this);
   }
 
   private void initLocationTracking() {

--- a/lost-sample/src/main/res/layout/activity_geofencing.xml
+++ b/lost-sample/src/main/res/layout/activity_geofencing.xml
@@ -6,20 +6,6 @@
     android:padding="8dp"
     >
 
-  <Button
-      android:id="@+id/button_connect"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:text="@string/connect"
-      />
-
-  <Button
-      android:id="@+id/button_disconnect"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:text="@string/disconnect"
-      />
-
   <TextView
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
@@ -77,6 +63,7 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/create"
+      android:enabled="false"
       />
 
 </LinearLayout>

--- a/lost/src/main/java/com/mapzen/android/lost/api/LostApiClient.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LostApiClient.java
@@ -5,6 +5,8 @@ import com.mapzen.android.lost.internal.LostClientManager;
 
 import android.content.Context;
 
+import java.lang.ref.WeakReference;
+
 public interface LostApiClient {
 
   interface ConnectionCallbacks {
@@ -18,21 +20,27 @@ public interface LostApiClient {
 
   boolean isConnected();
 
+  void unregisterConnectionCallbacks(ConnectionCallbacks callbacks);
+
   final class Builder {
     private final Context context;
-    private ConnectionCallbacks connectionCallbacks;
+    private WeakReference<ConnectionCallbacks> connectionCallbacks;
 
     public Builder(Context context) {
       this.context = context.getApplicationContext();
     }
 
     public Builder addConnectionCallbacks(ConnectionCallbacks callbacks) {
-      this.connectionCallbacks = callbacks;
+      this.connectionCallbacks = new WeakReference(callbacks);
       return this;
     }
 
     public LostApiClient build() {
-      return new LostApiClientImpl(context, connectionCallbacks, LostClientManager.shared());
+      ConnectionCallbacks callbacks = null;
+      if (connectionCallbacks != null) {
+        callbacks = connectionCallbacks.get();
+      }
+      return new LostApiClientImpl(context, callbacks, LostClientManager.shared());
     }
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
@@ -133,7 +133,6 @@ public class GeofencingApiImpl extends ApiImpl implements GeofencingApi {
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   @Override public PendingResult<Status> removeGeofences(LostApiClient client,
       PendingIntent pendingIntent) throws SecurityException {
-
     throwIfNotConnected(client);
     boolean hasResult = false;
     if (pendingIntentMap.values().contains(pendingIntent)) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/GeofencingApiImpl.java
@@ -133,6 +133,7 @@ public class GeofencingApiImpl extends ApiImpl implements GeofencingApi {
   @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
   @Override public PendingResult<Status> removeGeofences(LostApiClient client,
       PendingIntent pendingIntent) throws SecurityException {
+
     throwIfNotConnected(client);
     boolean hasResult = false;
     if (pendingIntentMap.values().contains(pendingIntent)) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostApiClientImpl.java
@@ -10,7 +10,7 @@ import android.content.Context;
  */
 public class LostApiClientImpl implements LostApiClient {
   private final Context context;
-  private final ConnectionCallbacks connectionCallbacks;
+  private ConnectionCallbacks connectionCallbacks;
   private final ClientManager clientManager;
 
   public LostApiClientImpl(Context context, ConnectionCallbacks callbacks,
@@ -64,6 +64,11 @@ public class LostApiClientImpl implements LostApiClient {
   @Override public boolean isConnected() {
     return getGeofencingImpl().isConnected() && getSettingsApiImpl().isConnected()
         && getFusedLocationProviderApiImpl().isConnected() && clientManager.containsClient(this);
+  }
+
+  @Override public void unregisterConnectionCallbacks(ConnectionCallbacks callbacks) {
+    getFusedLocationProviderApiImpl().removeConnectionCallbacks(connectionCallbacks);
+    connectionCallbacks = null;
   }
 
   private GeofencingApiImpl getGeofencingImpl() {


### PR DESCRIPTION
### Overview
This PR adds `LostApiClient#unregisterConnectionCallbacks` so that developers can prevent leaking resources when adding callbacks in `LostApiClient.Builder.addConnectionCallbacks`

It also updates the sample app examples to use cleanup registered callbacks.

Future work will add `LostApiClient#registerConnectionCallbacks` to allow adding callbacks after the client has been created

Closes #206 
