### PR TITLE
Ignore gh-pages on Circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,10 @@ test:
   override:
     - ./gradlew -PdisablePreDex
 
+branches:
+  ignore:
+    - gh-pages
+
 deployment:
   master:
     branch: master


### PR DESCRIPTION
### Overview
Our `gh-pages` branch is just documentation which means no tests get run but circle kicks off a build when changes are pushed to this branch. We recently updated documentation deployment so that every `master` build would refresh the docs and therefore push to `gh-pages`. These `gh-pages` builds are noisy (they send a "No tests: mapzen/lost on gh-pages" email) and unnecessary. This PR updates circle to not run builds for changes to the `gh-pages` branch 

### Proposed Changes
https://circleci.com/docs/2.0/configuration-reference/#branches