### PR TITLE
fix #224

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -39,15 +39,9 @@ public class FusedLocationProviderApiImpl extends ApiImpl
 
   IFusedLocationProviderService service;
 
-  IFusedLocationProviderCallback.Stub remoteCallback
+  private IFusedLocationProviderCallback.Stub remoteCallback
       = new IFusedLocationProviderCallback.Stub() {
     public void onLocationChanged(final Location location) throws RemoteException {
-
-      if (service == null) {
-        throw new IllegalStateException("Location update received after client was "
-                + "disconnected. Did you forget to unregister location updates before "
-                + "disconnecting?");
-      }
 
       new Handler(Looper.getMainLooper()).post(new Runnable() {
         @Override public void run() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceCallbackManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceCallbackManager.java
@@ -18,8 +18,7 @@ public class FusedLocationServiceCallbackManager {
   /**
    * Called when a new location has been received. This method handles dispatching changes to all
    * {@link com.mapzen.android.lost.api.LocationListener}s, {@link android.app.PendingIntent}s, and
-   * {@link com.mapzen.android.lost.api.LocationCallback}s which are registered. If the
-   * {@link IFusedLocationProviderService} is null, an {@link IllegalStateException} will be thrown.
+   * {@link com.mapzen.android.lost.api.LocationCallback}s which are registered.
    * @param context
    * @param location
    * @param clientManager
@@ -27,11 +26,6 @@ public class FusedLocationServiceCallbackManager {
    */
   void onLocationChanged(Context context, Location location, LostClientManager clientManager,
       IFusedLocationProviderService service) {
-    if (service == null) {
-      throw new IllegalStateException("Location update received after client was "
-          + "disconnected. Did you forget to unregister location updates before "
-          + "disconnecting?");
-    }
 
     ReportedChanges changes = clientManager.reportLocationChanged(location);
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -155,12 +155,6 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
         new TestLocationCallback(), Looper.myLooper());
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void onLocationChanged_shouldThrowIfServiceDisconnected() throws RemoteException {
-    api.service = null;
-    api.remoteCallback.onLocationChanged(null);
-  }
-
   @Test public void requestLocationUpdates_listener_shouldCallService() throws Exception {
     LocationRequest request = LocationRequest.create();
     LocationListener listener = new TestLocationListener();

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -24,6 +24,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
 import android.os.Looper;
+import android.os.RemoteException;
 import android.support.annotation.NonNull;
 
 import java.util.ArrayList;
@@ -152,6 +153,12 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
     connectedClient.disconnect();
     api.requestLocationUpdates(connectedClient, LocationRequest.create(),
         new TestLocationCallback(), Looper.myLooper());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void onLocationChanged_shouldThrowIfServiceDisconnected() throws RemoteException {
+    api.service = null;
+    api.remoteCallback.onLocationChanged(null);
   }
 
   @Test public void requestLocationUpdates_listener_shouldCallService() throws Exception {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationServiceCallbackManagerTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationServiceCallbackManagerTest.java
@@ -20,12 +20,6 @@ public class FusedLocationServiceCallbackManagerTest {
   FusedLocationServiceCallbackManager callbackManager =
       new FusedLocationServiceCallbackManager();
 
-  @Test(expected = IllegalStateException.class)
-  public void onLocationChanged_shouldThrowIfServiceDisconnected() {
-    callbackManager.onLocationChanged(mock(Context.class), mock(Location.class),
-        mock(LostClientManager.class), null);
-  }
-
   @Test public void onLocationChanged_shouldReportLocationChanged() {
     LostClientManager clientManager = mock(LostClientManager.class);
     Location location = mock(Location.class);


### PR DESCRIPTION
The problem is at [FusedLocationProviderApiImpl line 48](https://github.com/mapzen/lost/blob/master/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java#L48). The null check must be done immediately on the calling thread, not deferred.

This fix was made blindly: I did not verify if the tests still run because the test setup does not work on my machine (I suppose because I am on Windows): `No such manifest file: build\intermediates\bundles\debug\--none`