### PR TITLE
Log Exceptions

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -37,6 +37,8 @@ public interface FusedLocationProviderApi {
    * Network location is enabled and the {@link android.location.LocationManager} has a last known
    * Network location
    *
+   * This method can return null if there is a problem getting the availability.
+   *
    * @param client The client to return availability for.
    * @return The availability of location data.
    * @throws IllegalStateException if the client is not connected at the time of this call.

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -20,6 +20,7 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
 import android.os.RemoteException;
+import android.util.Log;
 
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ import java.util.Set;
 public class FusedLocationProviderApiImpl extends ApiImpl
     implements FusedLocationProviderApi, EventCallbacks, ServiceConnection {
 
+  private static final String TAG = FusedLocationProviderApiImpl.class.getSimpleName();
   private Context context;
   private FusedLocationServiceConnectionManager serviceConnectionManager;
   private FusedLocationServiceCallbackManager serviceCallbackManager;
@@ -123,19 +125,25 @@ public class FusedLocationProviderApiImpl extends ApiImpl
 
   @Override public Location getLastLocation(LostApiClient client) {
     throwIfNotConnected(client);
+    Location location = null;
     try {
-      return service.getLastLocation();
+      location = service.getLastLocation();
     } catch (RemoteException e) {
-      throw new RuntimeException(e);
+      Log.e(TAG, "Error occurred trying to get last Location " + e.getStackTrace());
+    } finally {
+      return location;
     }
   }
 
   @Override public LocationAvailability getLocationAvailability(LostApiClient client) {
     throwIfNotConnected(client);
+    LocationAvailability availability = null;
     try {
-      return service.getLocationAvailability();
+      availability = service.getLocationAvailability();
     } catch (RemoteException e) {
-      throw new RuntimeException(e);
+      Log.e(TAG, "Error occurred trying to get LocationAvailability " + e.getStackTrace());
+    } finally {
+      return availability;
     }
   }
 
@@ -179,7 +187,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     try {
       service.requestLocationUpdates(request);
     } catch (RemoteException e) {
-      throw new RuntimeException(e);
+      Log.e(TAG, "Error occurred trying to request location updates " + e.getStackTrace());
     }
   }
 
@@ -190,7 +198,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     try {
       service.removeLocationUpdates(requests);
     } catch (RemoteException e) {
-      throw new RuntimeException(e);
+      Log.e(TAG, "Error occurred trying to remove location updates " + e.getStackTrace());
     }
   }
 
@@ -244,7 +252,8 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     try {
       service.setMockMode(isMockMode);
     } catch (RemoteException e) {
-      throw new RuntimeException(e);
+      String mode = isMockMode ? "enabled" : "disabled";
+      Log.e(TAG, "Error occurred trying to set mock mode " + mode + " " + e.getStackTrace());
     }
     return new SimplePendingResult(true);
   }
@@ -255,7 +264,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     try {
       service.setMockLocation(mockLocation);
     } catch (RemoteException e) {
-      throw new RuntimeException(e);
+      Log.e(TAG, "Error occurred trying to set mock location " + e.getStackTrace());
     }
     return new SimplePendingResult(true);
   }
@@ -266,7 +275,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     try {
       service.setMockTrace(path, filename);
     } catch (RemoteException e) {
-      throw new RuntimeException(e);
+      Log.e(TAG, "Error occurred trying to set mock trace " + e.getStackTrace());
     }
     return new SimplePendingResult(true);
   }
@@ -288,7 +297,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
       try {
         service.init(remoteCallback);
       } catch (RemoteException e) {
-        throw new RuntimeException(e);
+        Log.e(TAG, "Error occurred trying to register remote callback " + e.getStackTrace());
       }
     }
   }
@@ -298,7 +307,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
       try {
         service.init(null);
       } catch (RemoteException e) {
-        throw new RuntimeException(e);
+        Log.e(TAG, "Error occurred trying to unregister remote callback " + e.getStackTrace());
       }
     }
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -129,7 +129,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     try {
       location = service.getLastLocation();
     } catch (RemoteException e) {
-      Log.e(TAG, "Error occurred trying to get last Location " + e.getStackTrace());
+      Log.e(TAG, "Error occurred trying to get last Location", e);
     } finally {
       return location;
     }
@@ -141,7 +141,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     try {
       availability = service.getLocationAvailability();
     } catch (RemoteException e) {
-      Log.e(TAG, "Error occurred trying to get LocationAvailability " + e.getStackTrace());
+      Log.e(TAG, "Error occurred trying to get LocationAvailability", e);
     } finally {
       return availability;
     }
@@ -187,7 +187,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     try {
       service.requestLocationUpdates(request);
     } catch (RemoteException e) {
-      Log.e(TAG, "Error occurred trying to request location updates " + e.getStackTrace());
+      Log.e(TAG, "Error occurred trying to request location updates", e);
     }
   }
 
@@ -198,7 +198,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     try {
       service.removeLocationUpdates(requests);
     } catch (RemoteException e) {
-      Log.e(TAG, "Error occurred trying to remove location updates " + e.getStackTrace());
+      Log.e(TAG, "Error occurred trying to remove location updates", e);
     }
   }
 
@@ -253,7 +253,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
       service.setMockMode(isMockMode);
     } catch (RemoteException e) {
       String mode = isMockMode ? "enabled" : "disabled";
-      Log.e(TAG, "Error occurred trying to set mock mode " + mode + " " + e.getStackTrace());
+      Log.e(TAG, "Error occurred trying to set mock mode " + mode, e);
     }
     return new SimplePendingResult(true);
   }
@@ -264,7 +264,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     try {
       service.setMockLocation(mockLocation);
     } catch (RemoteException e) {
-      Log.e(TAG, "Error occurred trying to set mock location " + e.getStackTrace());
+      Log.e(TAG, "Error occurred trying to set mock location", e);
     }
     return new SimplePendingResult(true);
   }
@@ -275,7 +275,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     try {
       service.setMockTrace(path, filename);
     } catch (RemoteException e) {
-      Log.e(TAG, "Error occurred trying to set mock trace " + e.getStackTrace());
+      Log.e(TAG, "Error occurred trying to set mock trace", e);
     }
     return new SimplePendingResult(true);
   }
@@ -297,7 +297,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
       try {
         service.init(remoteCallback);
       } catch (RemoteException e) {
-        Log.e(TAG, "Error occurred trying to register remote callback " + e.getStackTrace());
+        Log.e(TAG, "Error occurred trying to register remote callback", e);
       }
     }
   }
@@ -307,7 +307,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
       try {
         service.init(null);
       } catch (RemoteException e) {
-        Log.e(TAG, "Error occurred trying to unregister remote callback " + e.getStackTrace());
+        Log.e(TAG, "Error occurred trying to unregister remote callback", e);
       }
     }
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.os.Looper;
 import android.os.RemoteException;
 import android.support.annotation.RequiresPermission;
+import android.util.Log;
 
 import java.io.File;
 import java.util.List;
@@ -19,6 +20,7 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
 public class FusedLocationProviderServiceDelegate implements LocationEngine.Callback {
 
+  private static final String TAG = FusedLocationProviderServiceDelegate.class.getSimpleName();
   private Context context;
 
   private boolean mockMode;
@@ -76,7 +78,8 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
       try {
         callback.onLocationChanged(location);
       } catch (RemoteException e) {
-        throw new RuntimeException(e);
+        Log.e(TAG, "Error occurred trying to report a new Location. "
+            + e.getStackTrace().toString());
       }
     }
   }
@@ -130,7 +133,8 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
       try {
         callback.onLocationAvailabilityChanged(availability);
       } catch (RemoteException e) {
-        throw new RuntimeException(e);
+        Log.e(TAG, "Error occurred trying to report a new LocationAvailability. "
+            + e.getStackTrace().toString());
       }
     }
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
@@ -78,8 +78,7 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
       try {
         callback.onLocationChanged(location);
       } catch (RemoteException e) {
-        Log.e(TAG, "Error occurred trying to report a new Location. "
-            + e.getStackTrace().toString());
+        Log.e(TAG, "Error occurred trying to report a new Location", e);
       }
     }
   }
@@ -133,8 +132,7 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
       try {
         callback.onLocationAvailabilityChanged(availability);
       } catch (RemoteException e) {
-        Log.e(TAG, "Error occurred trying to report a new LocationAvailability. "
-            + e.getStackTrace().toString());
+        Log.e(TAG, "Error occurred trying to report a new LocationAvailability", e);
       }
     }
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceCallbackManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceCallbackManager.java
@@ -6,8 +6,11 @@ import com.mapzen.android.lost.api.LocationResult;
 import android.content.Context;
 import android.location.Location;
 import android.os.RemoteException;
+import android.util.Log;
 
 import java.util.ArrayList;
+
+import static android.content.ContentValues.TAG;
 
 /**
  * Handles callbacks received in {@link FusedLocationProviderApiImpl} from
@@ -29,11 +32,11 @@ public class FusedLocationServiceCallbackManager {
 
     ReportedChanges changes = clientManager.reportLocationChanged(location);
 
-    LocationAvailability availability;
+    LocationAvailability availability = null;
     try {
       availability = service.getLocationAvailability();
     } catch (RemoteException e) {
-      throw new RuntimeException(e);
+      Log.e(TAG, "Error occurred trying to get LocationAvailability" + e.getStackTrace());
     }
 
     ArrayList<Location> locations = new ArrayList<>();

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceCallbackManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceCallbackManager.java
@@ -36,7 +36,7 @@ public class FusedLocationServiceCallbackManager {
     try {
       availability = service.getLocationAvailability();
     } catch (RemoteException e) {
-      Log.e(TAG, "Error occurred trying to get LocationAvailability" + e.getStackTrace());
+      Log.e(TAG, "Error occurred trying to get LocationAvailability", e);
     }
 
     ArrayList<Location> locations = new ArrayList<>();


### PR DESCRIPTION
### Overview
This is the [first step](https://github.com/mapzen/lost/issues/229) towards improving and standardizing exception handling in Lost. Currently we catch and re-throw `RuntimeExceptions` thrown when interacting with the service, a hard stance for a library to take. To work towards giving developers the chance to handle recovering from these cases, this PR updates Lost to silently ignore `RemoteExceptions`. Future work will provide complete APIs to allow developers to handle recovering from these states as they see fit. It will potentially migrate [existing silent failures](https://github.com/mapzen/lost/blob/master/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java#L144-L166) to use these new APIs.

Closes #218, #223 
