### PR TITLE
Multiple Processes

### DIFF
--- a/lost-sample/src/main/AndroidManifest.xml
+++ b/lost-sample/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
     <activity android:name=".MultipleLocationListenerMultipleClientsActivity"/>
     <activity android:name=".MultipleLocationListenerSingleClientActivity"/>
     <activity android:name=".MultiplePriorityMultipleClientsActivity"/>
+    <activity android:name=".MultipleProcessesActivity"/>
 
     <service
         android:name=".GeofenceIntentService"
@@ -48,7 +49,7 @@
         <action android:name="com.mapzen.lost.intent.action.PENDING_INTENT_SERVICE"/>
       </intent-filter>
     </service>
-
+    <service android:name=".ListenerService" android:process=":listenerservice"/>
 
   </application>
 </manifest>

--- a/lost-sample/src/main/java/com/example/lost/ListenerService.java
+++ b/lost-sample/src/main/java/com/example/lost/ListenerService.java
@@ -1,0 +1,57 @@
+package com.example.lost;
+
+import com.mapzen.android.lost.api.LocationListener;
+import com.mapzen.android.lost.api.LocationRequest;
+import com.mapzen.android.lost.api.LocationServices;
+import com.mapzen.android.lost.api.LostApiClient;
+
+import android.app.Service;
+import android.content.Intent;
+import android.location.Location;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+/**
+ * Service running in separate process to request location updates.
+ */
+public class ListenerService extends Service {
+
+  private static final String TAG = ListenerService.class.getSimpleName();
+
+  LostApiClient client;
+  LocationListener listener = new LocationListener() {
+    @Override public void onLocationChanged(Location location) {
+      Log.d(TAG, "Location Changed");
+    }
+  };
+
+  @Nullable @Override public IBinder onBind(Intent intent) {
+    return null;
+  }
+
+  @Override public void onCreate() {
+    super.onCreate();
+    client = new LostApiClient.Builder(this).addConnectionCallbacks(
+        new LostApiClient.ConnectionCallbacks() {
+      @Override public void onConnected() {
+        LocationRequest request = LocationRequest.create();
+        request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+        request.setInterval(100);
+
+        LocationServices.FusedLocationApi.requestLocationUpdates(client, request, listener);
+      }
+
+      @Override public void onConnectionSuspended() {
+
+      }
+    }).build();
+    client.connect();
+  }
+
+  @Override public void onDestroy() {
+    super.onDestroy();
+    LocationServices.FusedLocationApi.removeLocationUpdates(client, listener);
+    client.disconnect();
+  }
+}

--- a/lost-sample/src/main/java/com/example/lost/MultipleProcessesActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/MultipleProcessesActivity.java
@@ -1,0 +1,51 @@
+package com.example.lost;
+
+import com.mapzen.android.lost.api.LocationListener;
+import com.mapzen.android.lost.api.LocationRequest;
+import com.mapzen.android.lost.api.LocationServices;
+
+import android.content.Intent;
+import android.location.Location;
+import android.util.Log;
+import android.widget.Toast;
+
+/**
+ * Demonstrates two different processes requesting location updates.
+ */
+public class MultipleProcessesActivity extends PendingIntentActivity {
+
+  private static final String TAG = MultipleProcessesActivity.class.getSimpleName();
+
+  LocationListener listener = new LocationListener() {
+    @Override public void onLocationChanged(Location location) {
+      Log.d(TAG, "Location Changed");
+    }
+  };
+
+  @Override protected void onResume() {
+    super.onResume();
+    Intent intent = new Intent(this, ListenerService.class);
+    startService(intent);
+  }
+
+  @Override protected void onPause() {
+    super.onPause();
+    Intent intent = new Intent(this, ListenerService.class);
+    stopService(intent);
+  }
+
+  void requestLocationUpdates() {
+    LocationRequest request = LocationRequest.create();
+    request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+    request.setInterval(100);
+
+    LocationServices.FusedLocationApi.requestLocationUpdates(client, request, listener);
+
+    Toast.makeText(this, R.string.requested, Toast.LENGTH_SHORT).show();
+  }
+
+  void unregisterAndDisconnectClient() {
+    LocationServices.FusedLocationApi.removeLocationUpdates(client, listener);
+    disconnect();
+  }
+}

--- a/lost-sample/src/main/java/com/example/lost/PendingIntentActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/PendingIntentActivity.java
@@ -49,13 +49,12 @@ public class PendingIntentActivity extends LostApiClientActivity {
     Button disconnect = (Button) findViewById(R.id.disconnect);
     disconnect.setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
-        LocationServices.FusedLocationApi.removeLocationUpdates(client, pendingIntent);
-        disconnect();
+        unregisterAndDisconnectClient();
       }
     });
   }
 
-  private void requestLocationUpdates() {
+  void requestLocationUpdates() {
     LocationRequest request = LocationRequest.create();
     request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
     request.setInterval(100);
@@ -66,5 +65,10 @@ public class PendingIntentActivity extends LostApiClientActivity {
     LocationServices.FusedLocationApi.requestLocationUpdates(client, request, pendingIntent);
 
     Toast.makeText(PendingIntentActivity.this, R.string.requested, Toast.LENGTH_SHORT).show();
+  }
+
+  void unregisterAndDisconnectClient() {
+    LocationServices.FusedLocationApi.removeLocationUpdates(client, pendingIntent);
+    disconnect();
   }
 }

--- a/lost-sample/src/main/java/com/example/lost/SamplesList.java
+++ b/lost-sample/src/main/java/com/example/lost/SamplesList.java
@@ -28,6 +28,8 @@ public class SamplesList {
           MultipleLocationListenerSingleClientActivity.class),
       new Sample(R.string.sample_pending_intent_title,
           R.string.sample_pending_intent_description, PendingIntentActivity.class),
+      new Sample(R.string.sample_multiple_process_title,
+          R.string.sample_multiple_process_description, MultipleProcessesActivity.class),
       new Sample(R.string.sample_location_availability_title,
           R.string.sample_location_availability_description, LocationAvailabilityActivity.class)
   };

--- a/lost-sample/src/main/res/values/strings.xml
+++ b/lost-sample/src/main/res/values/strings.xml
@@ -82,5 +82,7 @@
   <string name="sample_single_client_diff_intervals_description">Demonstrates how a single client can request location updates at different fastest intervals</string>
   <string name="sample_multiple_clients_priorities_title">Multiple Clients w/different request priorities</string>
   <string name="sample_multiple_clients_priorities_description">Demonstrates multiple clients receiving location requests for different location priorities</string>
+  <string name="sample_multiple_process_title">Multiple processes w/different clients</string>
+  <string name="sample_multiple_process_description">Demonstrates using lost in the main app process as well as in a service running in its own process</string>
 
 </resources>

--- a/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderCallback.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderCallback.aidl
@@ -4,6 +4,8 @@ import com.mapzen.android.lost.api.LocationAvailability;
 
 interface IFusedLocationProviderCallback {
 
+  long uniqueId();
+
   void onLocationChanged(in Location location);
 
   void onLocationAvailabilityChanged(in LocationAvailability locationAvailability);

--- a/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderCallback.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderCallback.aidl
@@ -4,7 +4,7 @@ import com.mapzen.android.lost.api.LocationAvailability;
 
 interface IFusedLocationProviderCallback {
 
-  long uniqueId();
+  long pid();
 
   void onLocationChanged(in Location location);
 

--- a/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderService.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderService.aidl
@@ -6,7 +6,9 @@ import com.mapzen.android.lost.internal.IFusedLocationProviderCallback;
 
 interface IFusedLocationProviderService {
 
-  void init(in IFusedLocationProviderCallback callback);
+  void add(in IFusedLocationProviderCallback callback);
+
+  void remove(in IFusedLocationProviderCallback callback);
 
   Location getLastLocation();
 

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationRequest.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationRequest.java
@@ -26,7 +26,7 @@ public final class LocationRequest implements Parcelable {
       return myPid();
     }
   };
-  private long pid;
+  long pid;
 
   private LocationRequest() {
     commonInit();
@@ -54,6 +54,7 @@ public final class LocationRequest implements Parcelable {
     this.setFastestInterval(incoming.getFastestInterval());
     this.setSmallestDisplacement(incoming.getSmallestDisplacement());
     this.setPriority(incoming.getPriority());
+    this.pid = incoming.pid;
   }
 
   public long getInterval() {

--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationRequest.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationRequest.java
@@ -1,7 +1,11 @@
 package com.mapzen.android.lost.api;
 
+import com.mapzen.android.lost.internal.PidReader;
+
 import android.os.Parcel;
 import android.os.Parcelable;
+
+import static android.os.Process.myPid;
 
 public final class LocationRequest implements Parcelable {
   public static final int PRIORITY_HIGH_ACCURACY = 0x00000064;
@@ -17,12 +21,32 @@ public final class LocationRequest implements Parcelable {
   private long fastestInterval = DEFAULT_FASTEST_INTERVAL_IN_MS;
   private float smallestDisplacement = DEFAULT_SMALLEST_DISPLACEMENT_IN_METERS;
   private int priority = PRIORITY_BALANCED_POWER_ACCURACY;
+  private PidReader pidReader = new PidReader() {
+    @Override public long getPid() {
+      return myPid();
+    }
+  };
+  private long pid;
 
   private LocationRequest() {
+    commonInit();
+  }
+
+  private LocationRequest(PidReader reader) {
+    pidReader = reader;
+    commonInit();
+  }
+
+  private void commonInit() {
+    pid = pidReader.getPid();
   }
 
   public static LocationRequest create() {
     return new LocationRequest();
+  }
+
+  public static LocationRequest create(PidReader reader) {
+    return new LocationRequest(reader);
   }
 
   public LocationRequest(LocationRequest incoming) {
@@ -90,6 +114,9 @@ public final class LocationRequest implements Parcelable {
 
     LocationRequest that = (LocationRequest) o;
 
+    if (pid != that.pid) {
+      return false;
+    }
     if (interval != that.interval) {
       return false;
     }
@@ -109,6 +136,7 @@ public final class LocationRequest implements Parcelable {
         31 * result + (smallestDisplacement != +0.0f ? Float.floatToIntBits(smallestDisplacement)
             : 0);
     result = 31 * result + priority;
+    result = 31 * result + (int) pid;
     return result;
   }
 
@@ -121,6 +149,7 @@ public final class LocationRequest implements Parcelable {
     dest.writeLong(this.fastestInterval);
     dest.writeFloat(this.smallestDisplacement);
     dest.writeInt(this.priority);
+    dest.writeLong(this.pid);
   }
 
   protected LocationRequest(Parcel in) {
@@ -128,6 +157,7 @@ public final class LocationRequest implements Parcelable {
     this.fastestInterval = in.readLong();
     this.smallestDisplacement = in.readFloat();
     this.priority = in.readInt();
+    this.pid = in.readLong();
   }
 
   public static final Parcelable.Creator<LocationRequest> CREATOR =

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static android.os.Process.myPid;
+
 /**
  * Implementation of the {@link FusedLocationProviderApi}.
  */
@@ -43,6 +45,13 @@ public class FusedLocationProviderApiImpl extends ApiImpl
 
   IFusedLocationProviderCallback.Stub remoteCallback
       = new IFusedLocationProviderCallback.Stub() {
+
+    final long id = System.currentTimeMillis() + myPid();
+
+    public long uniqueId() throws RemoteException {
+      return id;
+    }
+
     public void onLocationChanged(final Location location) throws RemoteException {
 
       new Handler(Looper.getMainLooper()).post(new Runnable() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -41,7 +41,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
 
   IFusedLocationProviderService service;
 
-  private IFusedLocationProviderCallback.Stub remoteCallback
+  IFusedLocationProviderCallback.Stub remoteCallback
       = new IFusedLocationProviderCallback.Stub() {
     public void onLocationChanged(final Location location) throws RemoteException {
 
@@ -295,7 +295,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
   void registerRemoteCallback() {
     if (service != null) {
       try {
-        service.init(remoteCallback);
+        service.add(remoteCallback);
       } catch (RemoteException e) {
         Log.e(TAG, "Error occurred trying to register remote callback", e);
       }
@@ -305,7 +305,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
   void unregisterRemoteCallback() {
     if (service != null) {
       try {
-        service.init(null);
+        service.remove(remoteCallback);
       } catch (RemoteException e) {
         Log.e(TAG, "Error occurred trying to unregister remote callback", e);
       }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -46,10 +46,8 @@ public class FusedLocationProviderApiImpl extends ApiImpl
   IFusedLocationProviderCallback.Stub remoteCallback
       = new IFusedLocationProviderCallback.Stub() {
 
-    final long id = System.currentTimeMillis() + myPid();
-
-    public long uniqueId() throws RemoteException {
-      return id;
+    public long pid() throws RemoteException {
+      return myPid();
     }
 
     public void onLocationChanged(final Location location) throws RemoteException {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
@@ -21,8 +21,13 @@ public class FusedLocationProviderService extends Service {
 
   private final IFusedLocationProviderService.Stub binder =
       new IFusedLocationProviderService.Stub() {
-        @Override public void init(IFusedLocationProviderCallback callback) throws RemoteException {
-          delegate.init(callback);
+        @Override public void add(IFusedLocationProviderCallback callback) throws RemoteException {
+          delegate.add(callback);
+        }
+
+        @Override public void remove(IFusedLocationProviderCallback callback) throws
+            RemoteException {
+          delegate.remove(callback);
         }
 
         @Override public Location getLastLocation() throws RemoteException {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegate.java
@@ -38,7 +38,7 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
 
   public void add(IFusedLocationProviderCallback callback) {
     try {
-      callbacks.put(callback.uniqueId(), callback);
+      callbacks.put(callback.pid(), callback);
     } catch (RemoteException e) {
       Log.e(TAG, "Error getting callback's unique id", e);
     }
@@ -46,7 +46,7 @@ public class FusedLocationProviderServiceDelegate implements LocationEngine.Call
 
   public void remove(IFusedLocationProviderCallback callback) {
     try {
-      callbacks.remove(callback.uniqueId());
+      callbacks.remove(callback.pid());
     } catch (RemoteException e) {
       Log.e(TAG, "Error getting callback's unique id", e);
     }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LocationEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LocationEngine.java
@@ -51,7 +51,7 @@ public abstract class LocationEngine {
   /**
    * Disables the engine when no requests remain, otherwise updates the engine's configuration.
    *
-   * @param request Valid location request to enable.
+   * @param requests Valid location request to enable.
    */
   public void removeRequests(List<LocationRequest> requests) {
     if (request != null) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/PidReader.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/PidReader.java
@@ -1,0 +1,12 @@
+package com.mapzen.android.lost.internal;
+
+/**
+ * Generic interface for returning process id.
+ */
+public interface PidReader {
+  /**
+   * Gets the process id.
+   * @return
+   */
+  long getPid();
+}

--- a/lost/src/test/java/com/mapzen/android/lost/api/LocationRequestTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/api/LocationRequestTest.java
@@ -94,5 +94,6 @@ public class LocationRequestTest extends BaseRobolectricTest {
     assertThat(rehydrated.getFastestInterval()).isEqualTo(dehydrated.getFastestInterval());
     assertThat(rehydrated.getSmallestDisplacement())
         .isEqualTo(dehydrated.getSmallestDisplacement());
+    assertThat(rehydrated.pid).isEqualTo(dehydrated.pid);
   }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/api/LocationSettingsRequestTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/api/LocationSettingsRequestTest.java
@@ -1,5 +1,7 @@
 package com.mapzen.android.lost.api;
 
+import com.mapzen.android.lost.internal.TestPidReader;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -15,13 +17,13 @@ public class LocationSettingsRequestTest {
 
   @Before public void setup() {
     requests = new ArrayList<>();
-    LocationRequest highAccuracy = LocationRequest.create().setPriority(
+    LocationRequest highAccuracy = LocationRequest.create(new TestPidReader()).setPriority(
         LocationRequest.PRIORITY_HIGH_ACCURACY); //gps + wifi
-    LocationRequest balancedPowerAccuracy = LocationRequest.create().setPriority(
+    LocationRequest balancedPowerAccuracy = LocationRequest.create(new TestPidReader()).setPriority(
         LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY); // wifi
-    LocationRequest lowPower = LocationRequest.create().setPriority(
+    LocationRequest lowPower = LocationRequest.create(new TestPidReader()).setPriority(
         LocationRequest.PRIORITY_LOW_POWER); // wifi
-    LocationRequest noPower = LocationRequest.create().setPriority(
+    LocationRequest noPower = LocationRequest.create(new TestPidReader()).setPriority(
         LocationRequest.PRIORITY_NO_POWER); // gps or wifi or none
     requests.add(highAccuracy);
     requests.add(balancedPowerAccuracy);

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -284,7 +284,7 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
   @Test public void onServiceConnected_shouldRegisterServiceCallbacks() throws Exception {
     TestServiceStub binder = new TestServiceStub();
     api.onServiceConnected(binder);
-    assertThat(binder.callback).isNotNull();
+    assertThat(binder.callbacks).isNotEmpty();
   }
 
   @Test public void onDisconnect_shouldUnbindServiceIfBound() throws Exception {
@@ -314,7 +314,7 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
     Context context = mock(Context.class);
     api.onConnect(context);
     api.onDisconnect();
-    verify(service).init(null);
+    verify(service).remove(api.remoteCallback);
   }
 
   @Test public void removeLocationUpdates_shouldReturnStatusSuccessIfListenerRemoved() {

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
@@ -393,7 +393,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     private Location location;
     private LocationAvailability locationAvailability;
 
-    @Override public long uniqueId() throws RemoteException {
+    @Override public long pid() throws RemoteException {
       return 1234;
     }
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
@@ -87,7 +87,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
 
   @Test public void requestLocationUpdates_shouldNotifyOnLocationChangedGps() throws Exception {
     TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
-    delegate.init(callback);
+    delegate.add(callback);
     delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
 
     Location location = new Location(GPS_PROVIDER);
@@ -97,7 +97,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
 
   @Test public void requestLocationUpdates_shouldNotifyOnLocationChangedNetwork() throws Exception {
     TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
-    delegate.init(callback);
+    delegate.add(callback);
     delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
 
     Location location = new Location(NETWORK_PROVIDER);
@@ -107,7 +107,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
 
   @Test public void requestLocationUpdates_shouldPreferGpsIfMoreAccurate() throws Exception {
     TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
-    delegate.init(callback);
+    delegate.add(callback);
     delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
 
     Location gpsLocation = getTestLocation(GPS_PROVIDER, 0, 0, 0);
@@ -122,7 +122,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
 
   @Test public void requestLocationUpdates_shouldPreferNetworkIfMoreAccurate() throws Exception {
     TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
-    delegate.init(callback);
+    delegate.add(callback);
     delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
 
     Location gpsLocation = getTestLocation(GPS_PROVIDER, 0, 0, 0);
@@ -177,7 +177,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
 
   @Test public void setMockLocation_shouldCallbackOnce() throws Exception {
     IFusedLocationProviderCallback callback = mock(IFusedLocationProviderCallback.class);
-    delegate.init(callback);
+    delegate.add(callback);
     Location mockLocation = new Location("mock");
     delegate.setMockMode(true);
     TestLocationListener listener = new TestLocationListener();
@@ -278,7 +278,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
 
   @Test public void requestLocationUpdates_shouldReportAvailability() {
     TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
-    delegate.init(callback);
+    delegate.add(callback);
     Location location = new Location("test");
     shadowLocationManager.setLastKnownLocation(NETWORK_PROVIDER, location);
     LocationRequest request = LocationRequest.create();
@@ -353,7 +353,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
 
   @Test public void reportProviderEnabled_shouldNotifyAvailabilityChanged() throws Exception {
     TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
-    delegate.init(callback);
+    delegate.add(callback);
     delegate.reportProviderEnabled(GPS_PROVIDER);
     assertThat(callback.locationAvailability).isNotNull();
   }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
@@ -358,6 +358,19 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     assertThat(callback.locationAvailability).isNotNull();
   }
 
+  @Test public void addCallback_shouldIncreaseCallbacksCount() {
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.add(callback);
+    assertThat(delegate.getCallbacks().size()).isEqualTo(1);
+  }
+
+  @Test public void removeCallback_shouldDecreaseCallbacksCount() {
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.add(callback);
+    delegate.remove(callback);
+    assertThat(delegate.getCallbacks().size()).isEqualTo(0);
+  }
+
   public class TestService extends IntentService {
     public TestService() {
       super("test service");
@@ -379,6 +392,10 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
   public class TestFusedLocationProviderCallback implements IFusedLocationProviderCallback {
     private Location location;
     private LocationAvailability locationAvailability;
+
+    @Override public long uniqueId() throws RemoteException {
+      return 1234;
+    }
 
     @Override public void onLocationChanged(Location location) throws RemoteException {
       this.location = location;

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LocationSettingsResultRequestTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LocationSettingsResultRequestTest.java
@@ -41,7 +41,8 @@ import static org.mockito.Mockito.when;
 
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest highAccuracy =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY); //gps + wifi
+        LocationRequest.create(new TestPidReader()).setPriority(
+            LocationRequest.PRIORITY_HIGH_ACCURACY); //gps + wifi
     requests.add(highAccuracy);
     request = new LocationSettingsRequest.Builder().addAllLocationRequests(requests)
         .setNeedBle(true)
@@ -166,9 +167,10 @@ import static org.mockito.Mockito.when;
 
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest balanced =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+        LocationRequest.create(new TestPidReader()).setPriority(
+            LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
     LocationRequest lowPower =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_LOW_POWER);
+        LocationRequest.create(new TestPidReader()).setPriority(LocationRequest.PRIORITY_LOW_POWER);
     requests.add(balanced);
     requests.add(lowPower);
     LocationSettingsRequest settingsRequest =
@@ -189,9 +191,10 @@ import static org.mockito.Mockito.when;
 
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest balanced =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+        LocationRequest.create(new TestPidReader()).setPriority(
+            LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
     LocationRequest lowPower =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_LOW_POWER);
+        LocationRequest.create(new TestPidReader()).setPriority(LocationRequest.PRIORITY_LOW_POWER);
     requests.add(balanced);
     requests.add(lowPower);
     LocationSettingsRequest settingsRequest =
@@ -213,9 +216,10 @@ import static org.mockito.Mockito.when;
 
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest balanced =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+        LocationRequest.create(new TestPidReader()).setPriority(
+            LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
     LocationRequest lowPower =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_LOW_POWER);
+        LocationRequest.create(new TestPidReader()).setPriority(LocationRequest.PRIORITY_LOW_POWER);
     requests.add(balanced);
     requests.add(lowPower);
     LocationSettingsRequest settingsRequest =
@@ -236,7 +240,7 @@ import static org.mockito.Mockito.when;
 
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest noPower =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_NO_POWER);
+        LocationRequest.create(new TestPidReader()).setPriority(LocationRequest.PRIORITY_NO_POWER);
     requests.add(noPower);
     LocationSettingsRequest settingsRequest =
         new LocationSettingsRequest.Builder().addAllLocationRequests(requests)
@@ -256,7 +260,7 @@ import static org.mockito.Mockito.when;
 
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest noPower =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_NO_POWER);
+        LocationRequest.create(new TestPidReader()).setPriority(LocationRequest.PRIORITY_NO_POWER);
     requests.add(noPower);
     LocationSettingsRequest settingsRequest =
         new LocationSettingsRequest.Builder().addAllLocationRequests(requests)
@@ -417,9 +421,10 @@ import static org.mockito.Mockito.when;
 
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest balanced =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+        LocationRequest.create(new TestPidReader()).setPriority(
+            LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
     LocationRequest lowPower =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_LOW_POWER);
+        LocationRequest.create(new TestPidReader()).setPriority(LocationRequest.PRIORITY_LOW_POWER);
     requests.add(balanced);
     requests.add(lowPower);
     LocationSettingsRequest settingsRequest =
@@ -444,9 +449,10 @@ import static org.mockito.Mockito.when;
 
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest balanced =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+        LocationRequest.create(new TestPidReader()).setPriority(
+            LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
     LocationRequest lowPower =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_LOW_POWER);
+        LocationRequest.create(new TestPidReader()).setPriority(LocationRequest.PRIORITY_LOW_POWER);
     requests.add(balanced);
     requests.add(lowPower);
     LocationSettingsRequest settingsRequest =
@@ -471,9 +477,10 @@ import static org.mockito.Mockito.when;
 
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest balanced =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+        LocationRequest.create(new TestPidReader()).setPriority(
+            LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
     LocationRequest lowPower =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_LOW_POWER);
+        LocationRequest.create(new TestPidReader()).setPriority(LocationRequest.PRIORITY_LOW_POWER);
     requests.add(balanced);
     requests.add(lowPower);
     LocationSettingsRequest settingsRequest =
@@ -497,7 +504,7 @@ import static org.mockito.Mockito.when;
 
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest noPower =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_NO_POWER);
+        LocationRequest.create(new TestPidReader()).setPriority(LocationRequest.PRIORITY_NO_POWER);
     requests.add(noPower);
     LocationSettingsRequest settingsRequest =
         new LocationSettingsRequest.Builder().addAllLocationRequests(requests)
@@ -520,7 +527,7 @@ import static org.mockito.Mockito.when;
 
     ArrayList<LocationRequest> requests = new ArrayList<>();
     LocationRequest noPower =
-        LocationRequest.create().setPriority(LocationRequest.PRIORITY_NO_POWER);
+        LocationRequest.create(new TestPidReader()).setPriority(LocationRequest.PRIORITY_NO_POWER);
     requests.add(noPower);
     LocationSettingsRequest settingsRequest =
         new LocationSettingsRequest.Builder().addAllLocationRequests(requests)

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostRequestManagerTests.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostRequestManagerTests.java
@@ -25,7 +25,7 @@ public class LostRequestManagerTests {
   @Test
   public void requestLocationUpdates_clientListener_oneRequest_shouldUpdateMap() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationListener listener = mock(LocationListener.class);
     requestManager.requestLocationUpdates(client, request, listener);
 
@@ -35,10 +35,10 @@ public class LostRequestManagerTests {
   @Test
   public void requestLocationUpdates_clientListener_twoRequests_shouldUpdateMap() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationListener listener = mock(LocationListener.class);
     requestManager.requestLocationUpdates(client, request, listener);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(client, anotherRequest, listener);
 
     assertThat(requestManager.getClientCallbackMap().size()).isEqualTo(1);
@@ -51,11 +51,11 @@ public class LostRequestManagerTests {
   @Test
   public void requestLocationUpdates_twoClientListeners_twoRequests_shouldUpdateMap() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationListener listener = mock(LocationListener.class);
     requestManager.requestLocationUpdates(client, request, listener);
     LostApiClient anotherClient = mock(LostApiClient.class);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(anotherClient, anotherRequest, listener);
 
     assertThat(requestManager.getClientCallbackMap().size()).isEqualTo(2);
@@ -72,7 +72,7 @@ public class LostRequestManagerTests {
   @Test
   public void requestLocationUpdates_clientPendingIntent_oneRequest_shouldUpdateMap() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     PendingIntent intent = mock(PendingIntent.class);
     requestManager.requestLocationUpdates(client, request, intent);
 
@@ -82,10 +82,10 @@ public class LostRequestManagerTests {
   @Test
   public void requestLocationUpdates_clientPendingIntent_twoRequests_shouldUpdateMap() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     PendingIntent intent = mock(PendingIntent.class);
     requestManager.requestLocationUpdates(client, request, intent);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(client, anotherRequest, intent);
 
     assertThat(requestManager.getClientCallbackMap().size()).isEqualTo(1);
@@ -98,11 +98,11 @@ public class LostRequestManagerTests {
   @Test
   public void requestLocationUpdates_twoClientPendingIntents_twoRequests_shouldUpdateMap() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     PendingIntent intent = mock(PendingIntent.class);
     requestManager.requestLocationUpdates(client, request, intent);
     LostApiClient anotherClient = mock(LostApiClient.class);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(anotherClient, anotherRequest, intent);
 
     assertThat(requestManager.getClientCallbackMap().size()).isEqualTo(2);
@@ -119,7 +119,7 @@ public class LostRequestManagerTests {
   @Test
   public void requestLocationUpdates_clientCallback_oneRequest_shouldUpdateMap() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationCallback callback = mock(LocationCallback.class);
     requestManager.requestLocationUpdates(client, request, callback);
 
@@ -129,10 +129,10 @@ public class LostRequestManagerTests {
   @Test
   public void requestLocationUpdates_clientCallback_twoRequests_shouldUpdateMap() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationCallback callback = mock(LocationCallback.class);
     requestManager.requestLocationUpdates(client, request, callback);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(client, anotherRequest, callback);
 
     assertThat(requestManager.getClientCallbackMap().size()).isEqualTo(1);
@@ -145,11 +145,11 @@ public class LostRequestManagerTests {
   @Test
   public void requestLocationUpdates_twoClientCallbacks_twoRequests_shouldUpdateMap() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationCallback callback = mock(LocationCallback.class);
     requestManager.requestLocationUpdates(client, request, callback);
     LostApiClient anotherClient = mock(LostApiClient.class);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(anotherClient, anotherRequest, callback);
 
     assertThat(requestManager.getClientCallbackMap().size()).isEqualTo(2);
@@ -166,7 +166,7 @@ public class LostRequestManagerTests {
   @Test
   public void removeLocationUpdates_clientListener_oneRequest_shouldRemoveAll() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationListener listener = mock(LocationListener.class);
     requestManager.requestLocationUpdates(client, request, listener);
     requestManager.removeLocationUpdates(client, listener);
@@ -177,10 +177,10 @@ public class LostRequestManagerTests {
   @Test
   public void removeLocationUpdates_clientListener_twoRequests_shouldRemoveAll() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationListener listener = mock(LocationListener.class);
     requestManager.requestLocationUpdates(client, request, listener);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(client, anotherRequest, listener);
     requestManager.removeLocationUpdates(client, listener);
 
@@ -190,11 +190,11 @@ public class LostRequestManagerTests {
   @Test
   public void removeLocationUpdates_twoClientListeners_twoRequests_shouldRemoveOne() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationListener listener = mock(LocationListener.class);
     requestManager.requestLocationUpdates(client, request, listener);
     LostApiClient anotherClient = mock(LostApiClient.class);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(anotherClient, anotherRequest, listener);
     requestManager.removeLocationUpdates(client, listener);
 
@@ -207,7 +207,7 @@ public class LostRequestManagerTests {
   @Test
   public void removeLocationUpdates_clientPendingIntent_oneRequest_shouldRemoveAll() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     PendingIntent intent = mock(PendingIntent.class);
     requestManager.requestLocationUpdates(client, request, intent);
     requestManager.removeLocationUpdates(client, intent);
@@ -218,10 +218,10 @@ public class LostRequestManagerTests {
   @Test
   public void removeLocationUpdates_clientPendingIntent_twoRequests_shouldRemoveAll() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     PendingIntent intent = mock(PendingIntent.class);
     requestManager.requestLocationUpdates(client, request, intent);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(client, anotherRequest, intent);
     requestManager.removeLocationUpdates(client, intent);
 
@@ -231,11 +231,11 @@ public class LostRequestManagerTests {
   @Test
   public void removeLocationUpdates_twoClientPendingIntents_twoRequests_shouldRemoveOne() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     PendingIntent intent = mock(PendingIntent.class);
     requestManager.requestLocationUpdates(client, request, intent);
     LostApiClient anotherClient = mock(LostApiClient.class);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(anotherClient, anotherRequest, intent);
     requestManager.removeLocationUpdates(client, intent);
 
@@ -248,7 +248,7 @@ public class LostRequestManagerTests {
   @Test
   public void removeLocationUpdates_clientCallback_oneRequest_shouldRemoveAll() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationCallback callback = mock(LocationCallback.class);
     requestManager.requestLocationUpdates(client, request, callback);
     requestManager.removeLocationUpdates(client, callback);
@@ -259,10 +259,10 @@ public class LostRequestManagerTests {
   @Test
   public void removeLocationUpdates_clientCallback_twoRequests_shouldRemoveAll() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationCallback callback = mock(LocationCallback.class);
     requestManager.requestLocationUpdates(client, request, callback);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(client, anotherRequest, callback);
     requestManager.removeLocationUpdates(client, callback);
 
@@ -272,11 +272,11 @@ public class LostRequestManagerTests {
   @Test
   public void removeLocationUpdates_twoClientCallbacks_twoRequests_shouldRemoveOne() {
     LostApiClient client = mock(LostApiClient.class);
-    LocationRequest request = LocationRequest.create();
+    LocationRequest request = LocationRequest.create(new TestPidReader());
     LocationCallback callback = mock(LocationCallback.class);
     requestManager.requestLocationUpdates(client, request, callback);
     LostApiClient anotherClient = mock(LostApiClient.class);
-    LocationRequest anotherRequest = LocationRequest.create();
+    LocationRequest anotherRequest = LocationRequest.create(new TestPidReader());
     requestManager.requestLocationUpdates(anotherClient, anotherRequest, callback);
     requestManager.removeLocationUpdates(client, callback);
 

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestPidReader.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestPidReader.java
@@ -1,0 +1,8 @@
+package com.mapzen.android.lost.internal;
+
+public class TestPidReader implements PidReader {
+
+  @Override public long getPid() {
+    return 0;
+  }
+}

--- a/lost/src/test/java/com/mapzen/android/lost/internal/TestServiceStub.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/TestServiceStub.java
@@ -6,14 +6,19 @@ import com.mapzen.android.lost.api.LocationRequest;
 import android.location.Location;
 import android.os.RemoteException;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class TestServiceStub extends IFusedLocationProviderService.Stub {
 
-  IFusedLocationProviderCallback callback;
+  List<IFusedLocationProviderCallback> callbacks = new ArrayList<>();
 
-  @Override public void init(IFusedLocationProviderCallback callback) throws RemoteException {
-    this.callback = callback;
+  @Override public void add(IFusedLocationProviderCallback callback) throws RemoteException {
+    this.callbacks.add(callback);
+  }
+
+  @Override public void remove(IFusedLocationProviderCallback callback) throws RemoteException {
+    this.callbacks.remove(callback);
   }
 
   @Override public Location getLastLocation() throws RemoteException {


### PR DESCRIPTION
### Overview
Updates the service delegate to allow multiple remote callbacks (previously only one was allowed).

### Proposed Changes
These changes update the service delegate to hold a `Map` of `IFusedLocationProviderCallback`s keyed off of the process id they were created in. This PR also updates `LocationRequest` to include a `pid` property to allow multiple processes to request & remove location updates for the same location parameters (interval, priority, etc) without effecting the other processes. Finally, it adds an example to the sample app to demonstrate using Lost in a `Service` running in its own process as well as an `Activity` running within the main process.

Closes #228 