### PR TITLE
Shutdown Client Manager

### DIFF
--- a/lost/src/main/java/com/mapzen/android/lost/api/LocationServices.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/LocationServices.java
@@ -6,6 +6,7 @@ import com.mapzen.android.lost.internal.FusedLocationServiceCallbackManager;
 import com.mapzen.android.lost.internal.FusedLocationServiceConnectionManager;
 import com.mapzen.android.lost.internal.GeofencingApiImpl;
 import com.mapzen.android.lost.internal.GeofencingServiceIntentFactory;
+import com.mapzen.android.lost.internal.LostClientManager;
 import com.mapzen.android.lost.internal.LostRequestManager;
 import com.mapzen.android.lost.internal.PendingIntentIdGenerator;
 import com.mapzen.android.lost.internal.SettingsApiImpl;
@@ -20,7 +21,8 @@ public class LocationServices {
    */
   public static final FusedLocationProviderApi FusedLocationApi =
       new FusedLocationProviderApiImpl(new FusedLocationServiceConnectionManager(),
-          new FusedLocationServiceCallbackManager(), LostRequestManager.shared());
+          new FusedLocationServiceCallbackManager(), LostRequestManager.shared(),
+          LostClientManager.shared());
 
   /**
    * Entry point for APIs concerning geofences.

--- a/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
@@ -41,6 +41,7 @@ public interface ClientManager {
   void updateReportedValues(ReportedChanges changes);
   void notifyLocationAvailability(final LocationAvailability availability);
   boolean hasNoListeners();
+  void shutdown();
   Map<LostApiClient, Set<LocationListener>> getLocationListeners();
   Map<LostApiClient, Set<PendingIntent>> getPendingIntents();
   Map<LostApiClient, Set<LocationCallback>> getLocationCallbacks();

--- a/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/ClientManager.java
@@ -17,7 +17,7 @@ import java.util.Set;
 
 /**
  * Used by {@link LostApiClientImpl} to manage connected clients and by
- * {@link FusedLocationProviderServiceDelegate} to manage client's {@link LocationListener}s,
+ * {@link FusedLocationProviderApiImpl} to manage client's {@link LocationListener}s,
  * {@link PendingIntent}s, and {@link LocationCallback}s.
  */
 public interface ClientManager {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -39,6 +39,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
   private FusedLocationServiceConnectionManager serviceConnectionManager;
   private FusedLocationServiceCallbackManager serviceCallbackManager;
   private RequestManager requestManager;
+  private ClientManager clientManager;
   private boolean isBound;
 
   IFusedLocationProviderService service;
@@ -56,7 +57,6 @@ public class FusedLocationProviderApiImpl extends ApiImpl
         @Override public void run() {
           // #224: this call is async, service may have been legally set to null in the meantime
           if (service != null) {
-            final LostClientManager clientManager = LostClientManager.shared();
             serviceCallbackManager.onLocationChanged(context, location, clientManager, service);
           }
         }
@@ -65,7 +65,6 @@ public class FusedLocationProviderApiImpl extends ApiImpl
 
     @Override public void onLocationAvailabilityChanged(LocationAvailability locationAvailability)
         throws RemoteException {
-      LostClientManager clientManager = LostClientManager.shared();
       serviceCallbackManager.onLocationAvailabilityChanged(locationAvailability, clientManager);
     }
   };
@@ -103,10 +102,12 @@ public class FusedLocationProviderApiImpl extends ApiImpl
   }
 
   public FusedLocationProviderApiImpl(FusedLocationServiceConnectionManager connectionManager,
-      FusedLocationServiceCallbackManager callbackManager, RequestManager requestManager) {
+      FusedLocationServiceCallbackManager callbackManager, RequestManager requestManager,
+      ClientManager clientManager) {
     serviceConnectionManager = connectionManager;
     serviceCallbackManager = callbackManager;
     this.requestManager = requestManager;
+    this.clientManager = clientManager;
     serviceConnectionManager.setEventCallbacks(this);
   }
 
@@ -158,7 +159,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
       LocationRequest request, LocationListener listener) {
     throwIfNotConnected(client);
     requestManager.requestLocationUpdates(client, request, listener);
-    LostClientManager.shared().addListener(client, request, listener);
+    clientManager.addListener(client, request, listener);
     requestLocationUpdatesInternal(request);
     return new SimplePendingResult(true);
   }
@@ -172,7 +173,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
       LocationRequest request, LocationCallback callback, Looper looper) {
     throwIfNotConnected(client);
     requestManager.requestLocationUpdates(client, request, callback);
-    LostClientManager.shared().addLocationCallback(client, request, callback, looper);
+    clientManager.addLocationCallback(client, request, callback, looper);
     requestLocationUpdatesInternal(request);
     return new SimplePendingResult(true);
   }
@@ -181,7 +182,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
       LocationRequest request, PendingIntent callbackIntent) {
     throwIfNotConnected(client);
     requestManager.requestLocationUpdates(client, request, callbackIntent);
-    LostClientManager.shared().addPendingIntent(client, request, callbackIntent);
+    clientManager.addPendingIntent(client, request, callbackIntent);
     requestLocationUpdatesInternal(request);
     return new SimplePendingResult(true);
   }
@@ -214,7 +215,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     throwIfNotConnected(client);
     List<LocationRequest> requests = requestManager.removeLocationUpdates(client, listener);
     removeLocationUpdatesInternal(requests);
-    boolean hasResult = LostClientManager.shared().removeListener(client, listener);
+    boolean hasResult = clientManager.removeListener(client, listener);
     checkAllListenersPendingIntentsAndCallbacks();
     return new SimplePendingResult(hasResult);
   }
@@ -224,7 +225,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     throwIfNotConnected(client);
     List<LocationRequest> requests = requestManager.removeLocationUpdates(client, callbackIntent);
     removeLocationUpdatesInternal(requests);
-    boolean hasResult = LostClientManager.shared().removePendingIntent(client, callbackIntent);
+    boolean hasResult = clientManager.removePendingIntent(client, callbackIntent);
     checkAllListenersPendingIntentsAndCallbacks();
     return new SimplePendingResult(hasResult);
   }
@@ -234,7 +235,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
     throwIfNotConnected(client);
     List<LocationRequest> requests = requestManager.removeLocationUpdates(client, callback);
     removeLocationUpdatesInternal(requests);
-    boolean hasResult = LostClientManager.shared().removeLocationCallback(client, callback);
+    boolean hasResult = clientManager.removeLocationCallback(client, callback);
     checkAllListenersPendingIntentsAndCallbacks();
     return new SimplePendingResult(hasResult);
   }
@@ -245,7 +246,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
    */
   private void checkAllListenersPendingIntentsAndCallbacks() {
     //TODO: potentially remove hasNoListeners method, not needed anymore
-    //if (LostClientManager.shared().hasNoListeners()) {
+    //if (clientManager.hasNoListeners()) {
     //  try {
     //    service.removeAllLocationUpdates();
     //  } catch (RemoteException e) {
@@ -288,7 +289,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
   }
 
   public Map<LostApiClient, Set<LocationListener>> getLocationListeners() {
-    return LostClientManager.shared().getLocationListeners();
+    return clientManager.getLocationListeners();
   }
 
   void removeConnectionCallbacks(LostApiClient.ConnectionCallbacks callbacks) {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImpl.java
@@ -87,7 +87,7 @@ public class FusedLocationProviderApiImpl extends ApiImpl
       context.unbindService(this);
       isBound = false;
     }
-
+    clientManager.shutdown();
     service = null;
   }
 

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceCallbackManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationServiceCallbackManager.java
@@ -27,7 +27,7 @@ public class FusedLocationServiceCallbackManager {
    * @param clientManager
    * @param service
    */
-  void onLocationChanged(Context context, Location location, LostClientManager clientManager,
+  void onLocationChanged(Context context, Location location, ClientManager clientManager,
       IFusedLocationProviderService service) {
 
     ReportedChanges changes = clientManager.reportLocationChanged(location);
@@ -53,13 +53,13 @@ public class FusedLocationServiceCallbackManager {
   }
 
   /**
-   * Handles notifying all registered {@link LocationCallback}s that {@link LocationAvailability}
-   * has changed.
+   * Handles notifying all registered {@link com.mapzen.android.lost.api.LocationCallback}s that
+   * {@link LocationAvailability} has changed.
    * @param locationAvailability
    * @param clientManager
    */
   void onLocationAvailabilityChanged(LocationAvailability locationAvailability,
-      LostClientManager clientManager) {
+      ClientManager clientManager) {
     clientManager.notifyLocationAvailability(locationAvailability);
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
@@ -24,7 +24,7 @@ import static com.mapzen.android.lost.api.FusedLocationProviderApi.KEY_LOCATION_
 
 /**
  * Used by {@link LostApiClientImpl} to manage connected clients and by
- * {@link FusedLocationProviderServiceDelegate} to manage client's {@link LocationListener}s,
+ * {@link FusedLocationProviderApiImpl} to manage client's {@link LocationListener}s,
  * {@link PendingIntent}s, and {@link LocationCallback}s.
  */
 public class LostClientManager implements ClientManager {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
@@ -212,6 +212,10 @@ public class LostClientManager implements ClientManager {
     return true;
   }
 
+  @Override public void shutdown() {
+    reportedChanges.clearAll();
+  }
+
   @VisibleForTesting void clearClients() {
     clients.clear();
   }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/ReportedChanges.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/ReportedChanges.java
@@ -36,4 +36,9 @@ public class ReportedChanges {
     updatedRequestToReportedTime.putAll(changes.timeChanges());
     updatedRequestToReportedLocation.putAll(changes.locationChanges());
   }
+
+  public void clearAll() {
+    updatedRequestToReportedTime.clear();
+    updatedRequestToReportedLocation.clear();
+  }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -319,6 +319,16 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
     verify(service).remove(api.remoteCallback);
   }
 
+  @Test public void onDisconnect_shouldShutdownClientManager() throws Exception {
+    Context context = mock(Context.class);
+    clientManager = mock(LostClientManager.class);
+    FusedLocationProviderApiImpl apiImpl = new FusedLocationProviderApiImpl(connectionManager,
+        new FusedLocationServiceCallbackManager(), requestManager, clientManager);
+    apiImpl.onConnect(context);
+    apiImpl.onDisconnect();
+    verify(clientManager).shutdown();
+  }
+
   @Test public void removeLocationUpdates_shouldReturnStatusSuccessIfListenerRemoved() {
     TestResultCallback callback = new TestResultCallback();
     TestLocationListener listener = new TestLocationListener();

--- a/lost/src/test/java/com/mapzen/android/lost/internal/ReportedChangesTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/ReportedChangesTest.java
@@ -1,0 +1,73 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LocationRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import android.location.Location;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class ReportedChangesTest {
+
+  Map<LocationRequest, Long> timeChanges = new HashMap<>();
+  Map<LocationRequest, Location> locationChanges = new HashMap<>();
+  ReportedChanges changes;
+
+  @Before public void setup() {
+    changes = new ReportedChanges(timeChanges, locationChanges);
+  }
+
+  @Test public void putAll_shouldUpdateTimeChanges() {
+    Map<LocationRequest, Long> otherTimeChanges = new HashMap<>();
+    LocationRequest locRequest = LocationRequest.create(new TestPidReader());
+    otherTimeChanges.put(locRequest, 1234L);
+    Map<LocationRequest, Location> otherLocationChanges = new HashMap<>();
+    ReportedChanges otherChanges = new ReportedChanges(otherTimeChanges, otherLocationChanges);
+    changes.putAll(otherChanges);
+    assertThat(changes.timeChanges().get(locRequest)).isEqualTo(1234L);
+  }
+
+  @Test public void putAll_shouldUpdateLocationChanges() {
+    Map<LocationRequest, Long> otherTimeChanges = new HashMap<>();
+    Map<LocationRequest, Location> otherLocationChanges = new HashMap<>();
+    LocationRequest locRequest = LocationRequest.create(new TestPidReader());
+    Location loc = mock(Location.class);
+    otherLocationChanges.put(locRequest, loc);
+    ReportedChanges otherChanges = new ReportedChanges(otherTimeChanges, otherLocationChanges);
+    changes.putAll(otherChanges);
+    assertThat(changes.locationChanges().get(locRequest)).isEqualTo(loc);
+  }
+
+  @Test public void clearAll_shouldClearTimeChanges() {
+    Map<LocationRequest, Long> otherTimeChanges = new HashMap<>();
+    LocationRequest locRequest = LocationRequest.create(new TestPidReader());
+    otherTimeChanges.put(locRequest, 1234L);
+    Map<LocationRequest, Location> otherLocationChanges = new HashMap<>();
+    Location loc = mock(Location.class);
+    otherLocationChanges.put(locRequest, loc);
+    ReportedChanges otherChanges = new ReportedChanges(otherTimeChanges, otherLocationChanges);
+    changes.putAll(otherChanges);
+    changes.clearAll();
+    assertThat(changes.timeChanges()).isEmpty();
+  }
+
+  @Test public void clearAll_shouldClearLocationChanges() {
+    Map<LocationRequest, Long> otherTimeChanges = new HashMap<>();
+    LocationRequest locRequest = LocationRequest.create(new TestPidReader());
+    otherTimeChanges.put(locRequest, 1234L);
+    Map<LocationRequest, Location> otherLocationChanges = new HashMap<>();
+    Location loc = mock(Location.class);
+    otherLocationChanges.put(locRequest, loc);
+    ReportedChanges otherChanges = new ReportedChanges(otherTimeChanges, otherLocationChanges);
+    changes.putAll(otherChanges);
+    changes.clearAll();
+    assertThat(changes.locationChanges()).isEmpty();
+  }
+
+}


### PR DESCRIPTION
### Overview
This fixes a bug which prevented initial location updates from consistently being sent when clients re-connect to Lost.

### Proposed Changes
The `ClientManager` is a shared singleton used by `LostApiClient` and `FusedLocationProviderApi` to report location updates. When the service is started for the first  time, the `ClientManager` doesn't have any `ReportedChanges` and always sends the first location received to registered listeners. When the service is stopped and restarted quickly, the last known location reported by the service may not have changed and because the `ClientManager`'s `ReportedChanges` were not cleared, the location reported might not be sent to registered listeners (because it was compared to "stale" `ReportedChanges`). This PR adds code to "shutdown" the `ClientManager` when the service disconnects so that expected initial location updates are always sent when clients re-connect.

Small improvements (constructor injection) were made to the `FusedLocationProviderApiImpl` to make testing easier.

Closes #233