### PR TITLE
Improve Circle builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   java:
     version: oraclejdk8
+  environment:
+    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
 
 dependencies:
   pre:


### PR DESCRIPTION
### Overview
Limits jvm heap to prevent build failures on circle

### Proposed Changes
https://circleci.com/docs/1.0/oom/#out-of-memory-errors-in-android-builds